### PR TITLE
feat: Add clear all annotations menu option

### DIFF
--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -132,6 +132,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
             menu.addItem(NSMenuItem.separator())
 
+            let clearAllItem = NSMenuItem(
+                title: "Clear All",
+                action: #selector(clearAllAnnotations),
+                keyEquivalent: "\u{8}"
+            )
+            clearAllItem.keyEquivalentModifierMask = [.option]
+            menu.addItem(clearAllItem)
+
             let undoItem = NSMenuItem(
                 title: "Undo",
                 action: #selector(undo),
@@ -361,6 +369,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             overlayWindow.isVisible
         {
             overlayWindow.overlayView.redo()
+        }
+    }
+
+    @objc func clearAllAnnotations() {
+        if let currentScreen = getCurrentScreen(),
+            let overlayWindow = overlayWindows[currentScreen],
+            overlayWindow.isVisible
+        {
+            overlayWindow.overlayView.clearAll()
         }
     }
 


### PR DESCRIPTION
This PR adds a dedicated "Clear All" menu item to the status bar dropdown menu with the Option+Delete (⌥+⌫) keyboard shortcut. While this functionality was already available via keyboard shortcut, making it visible in the menu improves discoverability and provides a more intuitive user experience.

## Changes
- Added a new "Clear All" menu item in the status bar dropdown
- Implemented the `clearAllAnnotations()` method to handle the action
- Set the keyboard shortcut to Option+Delete (⌥+⌫)

