### PR TITLE
feat: Add counter tool for numbered annotations 

### DIFF
--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -103,6 +103,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             circleModeItem.keyEquivalentModifierMask = []
             menu.addItem(circleModeItem)
 
+            let counterModeItem = NSMenuItem(
+                title: "Counter",
+                action: #selector(enableCounterMode(_:)),
+                keyEquivalent: ShortcutManager.shared.getShortcut(for: .counter))
+            counterModeItem.keyEquivalentModifierMask = []
+            menu.addItem(counterModeItem)
+
             let textModeItem = NSMenuItem(
                 title: "Text",
                 action: #selector(enableTextMode(_:)),
@@ -346,6 +353,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
+    @objc func enableCounterMode(_ sender: NSMenuItem) {
+        switchTool(to: .counter)
+        if let menu = statusItem.menu {
+            let currentToolItem = menu.item(at: 2)
+            currentToolItem?.title = "Current Tool: Counter"
+        }
+    }
+
     @objc func enableTextMode(_ sender: NSMenuItem) {
         switchTool(to: .text)
         if let menu = statusItem.menu {
@@ -391,8 +406,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         UserDefaults.standard.set(!isCurrentlyFadeMode, forKey: UserDefaults.fadeModeKey)
 
         if let menu = statusItem.menu {
-            let currentDrawingModeItem = menu.item(at: 10)
-            let toggleDrawingModeItem = menu.item(at: 11)
+            let currentDrawingModeItem = menu.item(at: 11)
+            let toggleDrawingModeItem = menu.item(at: 12)
 
             currentDrawingModeItem?.title =
                 isCurrentlyFadeMode

--- a/Annotate/Models.swift
+++ b/Annotate/Models.swift
@@ -8,6 +8,7 @@ enum ToolType {
     case rectangle
     case circle
     case text
+    case counter
 }
 
 /// Represents a timed point for pen/highlighter so we can do trailing fade-out
@@ -54,6 +55,13 @@ struct TextAnnotation {
     var fontSize: CGFloat
 }
 
+struct CounterAnnotation {
+    var number: Int
+    var position: NSPoint
+    var color: NSColor
+    var creationTime: CFTimeInterval?
+}
+
 /// Describes actions that can be used for undo/redo operations.
 enum DrawingAction {
     case addPath(DrawingPath)
@@ -61,15 +69,19 @@ enum DrawingAction {
     case addHighlight(DrawingPath)
     case addRectangle(Rectangle)
     case addCircle(Circle)
+    case addCounter(CounterAnnotation)
     case removePath(DrawingPath)
     case removeArrow(Arrow)
     case removeHighlight(DrawingPath)
     case removeRectangle(Rectangle)
     case removeCircle(Circle)
+    case removeCounter(CounterAnnotation)
     case addText(TextAnnotation)
     case removeText(TextAnnotation)
     case moveText(Int, NSPoint, NSPoint)
-    case clearAll([DrawingPath], [Arrow], [DrawingPath], [Rectangle], [Circle], [TextAnnotation])
+    case clearAll(
+        [DrawingPath], [Arrow], [DrawingPath], [Rectangle], [Circle], [TextAnnotation],
+        [CounterAnnotation])
 }
 
 // Add to Models.swift
@@ -110,5 +122,12 @@ extension TextAnnotation: Equatable {
     public static func == (lhs: TextAnnotation, rhs: TextAnnotation) -> Bool {
         return lhs.text == rhs.text && lhs.position == rhs.position && lhs.color.isEqual(rhs.color)
             && lhs.fontSize == rhs.fontSize
+    }
+}
+
+extension CounterAnnotation: Equatable {
+    public static func == (lhs: CounterAnnotation, rhs: CounterAnnotation) -> Bool {
+        return lhs.number == rhs.number && lhs.position == rhs.position
+            && lhs.color.isEqual(rhs.color) && lhs.creationTime == rhs.creationTime
     }
 }

--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -99,6 +99,25 @@ class OverlayWindow: NSWindow {
             overlayView.finalizeTextAnnotation(activeTextField)
         }
 
+        if overlayView.currentTool == .counter {
+            let counterAnnotation = CounterAnnotation(
+                number: overlayView.nextCounterNumber,
+                position: startPoint,
+                color: currentColor,
+                creationTime: CACurrentMediaTime()
+            )
+
+            overlayView.registerUndo(action: .addCounter(counterAnnotation))
+            overlayView.counterAnnotations.append(counterAnnotation)
+            overlayView.nextCounterNumber += 1
+            overlayView.needsDisplay = true
+
+            if overlayView.fadeMode {
+                startFadeLoop()
+            }
+            return
+        }
+
         if overlayView.currentTool == .text {
             for (index, annotation) in overlayView.textAnnotations.enumerated() {
                 let textRect = getTextRect(for: annotation)
@@ -162,6 +181,8 @@ class OverlayWindow: NSWindow {
             overlayView.currentCircle = Circle(
                 startPoint: startPoint, endPoint: startPoint, color: overlayView.currentColor)
         case .text:
+            break
+        case .counter:
             break
         }
         overlayView.needsDisplay = true
@@ -230,6 +251,8 @@ class OverlayWindow: NSWindow {
                 overlayView.currentCircle?.endPoint = currentPoint
             }
         case .text:
+            break
+        case .counter:
             break
         }
         overlayView.needsDisplay = true
@@ -311,6 +334,8 @@ class OverlayWindow: NSWindow {
             }
         case .text:
             break
+        case .counter:
+            break
         }
         overlayView.needsDisplay = true
         wasOptionPressedOnMouseDown = false
@@ -344,6 +369,9 @@ class OverlayWindow: NSWindow {
                 return
             case ShortcutManager.shared.getShortcut(for: .circle):
                 AppDelegate.shared?.enableCircleMode(NSMenuItem())
+                return
+            case ShortcutManager.shared.getShortcut(for: .counter):
+                AppDelegate.shared?.enableCounterMode(NSMenuItem())
                 return
             case ShortcutManager.shared.getShortcut(for: .text):
                 AppDelegate.shared?.enableTextMode(NSMenuItem())

--- a/Annotate/ShortcutManager.swift
+++ b/Annotate/ShortcutManager.swift
@@ -6,6 +6,7 @@ enum ShortcutKey: String, CaseIterable {
     case highlighter = "h"
     case rectangle = "r"
     case circle = "o"
+    case counter = "n"
     case text = "t"
     case colorPicker = "c"
 
@@ -18,6 +19,7 @@ enum ShortcutKey: String, CaseIterable {
         case .highlighter: return "Highlighter"
         case .rectangle: return "Rectangle"
         case .circle: return "Circle"
+        case .counter: return "Counter"
         case .text: return "Text"
         case .colorPicker: return "Color Picker"
         }

--- a/AnnotateTests/AppDelegateTests.swift
+++ b/AnnotateTests/AppDelegateTests.swift
@@ -68,6 +68,19 @@ final class AppDelegateTests: XCTestCase {
         }
     }
 
+    func testCounterToolSwitching() {
+        appDelegate.enableCounterMode(NSMenuItem())
+        for window in appDelegate.overlayWindows.values {
+            XCTAssertEqual(window.overlayView.currentTool, .counter)
+        }
+
+        if let menu = appDelegate.statusItem.menu,
+            let currentToolItem = menu.item(at: 2)
+        {
+            XCTAssertEqual(currentToolItem.title, "Current Tool: Counter")
+        }
+    }
+
     func testColorPicker() {
         appDelegate.showColorPicker(nil)
         XCTAssertNotNil(appDelegate.colorPopover)

--- a/AnnotateTests/DrawingActionTests.swift
+++ b/AnnotateTests/DrawingActionTests.swift
@@ -49,19 +49,57 @@ final class DrawingActionTests: XCTestCase {
         }
     }
 
-    func testClearAllAction() {
+    func testAddCounterAction() {
+        let counter = CounterAnnotation(
+            number: 1,
+            position: NSPoint(x: 100, y: 100),
+            color: .systemBlue
+        )
+
+        let action = DrawingAction.addCounter(counter)
+
+        if case .addCounter(let actionCounter) = action {
+            XCTAssertEqual(actionCounter.number, counter.number)
+            XCTAssertEqual(actionCounter.position, counter.position)
+            XCTAssertEqual(actionCounter.color, counter.color)
+        } else {
+            XCTFail("Wrong action type")
+        }
+    }
+
+    func testRemoveCounterAction() {
+        let counter = CounterAnnotation(
+            number: 2,
+            position: NSPoint(x: 200, y: 200),
+            color: .systemGreen
+        )
+
+        let action = DrawingAction.removeCounter(counter)
+
+        if case .removeCounter(let actionCounter) = action {
+            XCTAssertEqual(actionCounter.number, counter.number)
+            XCTAssertEqual(actionCounter.position, counter.position)
+            XCTAssertEqual(actionCounter.color, counter.color)
+        } else {
+            XCTFail("Wrong action type")
+        }
+    }
+
+    func testClearAllWithCounters() {
         let paths = [DrawingPath(points: [], color: .systemRed)]
         let arrows = [Arrow(startPoint: .zero, endPoint: .zero, color: .blue)]
         let highlights = [DrawingPath(points: [], color: .yellow)]
         let rectangles = [Rectangle(startPoint: .zero, endPoint: .zero, color: .green)]
         let circles = [Circle(startPoint: .zero, endPoint: .zero, color: .purple)]
         let texts = [TextAnnotation(text: "Test", position: .zero, color: .black, fontSize: 12)]
+        let counters = [CounterAnnotation(number: 1, position: .zero, color: .orange)]
 
-        let action = DrawingAction.clearAll(paths, arrows, highlights, rectangles, circles, texts)
+        let action = DrawingAction.clearAll(
+            paths, arrows, highlights, rectangles, circles, texts, counters)
 
         if case .clearAll(
             let actionPaths, let actionArrows, let actionHighlights,
-            let actionRects, let actionCircles, let actionTexts) = action
+            let actionRects, let actionCircles, let actionTexts, let actionCounters) = action
         {
             XCTAssertEqual(actionPaths, paths)
             XCTAssertEqual(actionArrows, arrows)
@@ -69,6 +107,35 @@ final class DrawingActionTests: XCTestCase {
             XCTAssertEqual(actionRects, rectangles)
             XCTAssertEqual(actionCircles, circles)
             XCTAssertEqual(actionTexts, texts)
+            XCTAssertEqual(actionCounters, counters)
+        } else {
+            XCTFail("Wrong action type")
+        }
+    }
+
+    func testClearAllAction() {
+        let paths = [DrawingPath(points: [], color: .systemRed)]
+        let arrows = [Arrow(startPoint: .zero, endPoint: .zero, color: .blue)]
+        let highlights = [DrawingPath(points: [], color: .yellow)]
+        let rectangles = [Rectangle(startPoint: .zero, endPoint: .zero, color: .green)]
+        let circles = [Circle(startPoint: .zero, endPoint: .zero, color: .purple)]
+        let texts = [TextAnnotation(text: "Test", position: .zero, color: .black, fontSize: 12)]
+        let counters = [CounterAnnotation(number: 1, position: .zero, color: .black)]
+
+        let action = DrawingAction.clearAll(
+            paths, arrows, highlights, rectangles, circles, texts, counters)
+
+        if case .clearAll(
+            let actionPaths, let actionArrows, let actionHighlights,
+            let actionRects, let actionCircles, let actionTexts, let actionCounters) = action
+        {
+            XCTAssertEqual(actionPaths, paths)
+            XCTAssertEqual(actionArrows, arrows)
+            XCTAssertEqual(actionHighlights, highlights)
+            XCTAssertEqual(actionRects, rectangles)
+            XCTAssertEqual(actionCircles, circles)
+            XCTAssertEqual(actionTexts, texts)
+            XCTAssertEqual(actionCounters, counters)
         } else {
             XCTFail("Wrong action type")
         }

--- a/AnnotateTests/ModelTests.swift
+++ b/AnnotateTests/ModelTests.swift
@@ -71,6 +71,48 @@ final class ModelTests: XCTestCase {
         XCTAssertTrue(emptyAnnotation.text.isEmpty)
     }
 
+    func testCounterAnnotation() {
+        let position = NSPoint(x: 50, y: 50)
+        let color = NSColor.blue
+        let number = 3
+        let time: CFTimeInterval = 1.5
+
+        let counter = CounterAnnotation(
+            number: number,
+            position: position,
+            color: color,
+            creationTime: time
+        )
+
+        XCTAssertEqual(counter.number, number)
+        XCTAssertEqual(counter.position, position)
+        XCTAssertEqual(counter.color, color)
+        XCTAssertEqual(counter.creationTime, time)
+
+        let counterNoTime = CounterAnnotation(
+            number: number,
+            position: position,
+            color: color
+        )
+        XCTAssertNil(counterNoTime.creationTime)
+
+        let counterCopy = CounterAnnotation(
+            number: number,
+            position: position,
+            color: color,
+            creationTime: time
+        )
+        XCTAssertEqual(counter, counterCopy)
+
+        let differentCounter = CounterAnnotation(
+            number: number + 1,
+            position: position,
+            color: color,
+            creationTime: time
+        )
+        XCTAssertNotEqual(counter, differentCounter)
+    }
+
     func testToolType() {
         let tools: [ToolType] = [.pen, .arrow, .highlighter, .rectangle, .circle, .text]
         XCTAssertEqual(tools.count, 6)  // Ensure we have all tool types

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -82,4 +82,59 @@ final class OverlayViewTests: XCTestCase {
         XCTAssertTrue(overlayView.circles.isEmpty)
         XCTAssertTrue(overlayView.textAnnotations.isEmpty)
     }
+
+    func testCounterAnnotations() {
+        XCTAssertTrue(overlayView.counterAnnotations.isEmpty)
+        XCTAssertEqual(overlayView.nextCounterNumber, 1)
+
+        let counter = CounterAnnotation(
+            number: 1,
+            position: NSPoint(x: 100, y: 100),
+            color: .systemBlue
+        )
+        overlayView.counterAnnotations.append(counter)
+        overlayView.nextCounterNumber = 2
+
+        // Verify counter was added
+        XCTAssertEqual(overlayView.counterAnnotations.count, 1)
+        XCTAssertEqual(overlayView.counterAnnotations[0].number, 1)
+        XCTAssertEqual(overlayView.nextCounterNumber, 2)
+
+        // Test clearing counters
+        overlayView.clearAll()
+        XCTAssertTrue(overlayView.counterAnnotations.isEmpty)
+        XCTAssertEqual(overlayView.nextCounterNumber, 1)
+    }
+
+    func testCounterToolSelection() {
+        overlayView.currentTool = .counter
+        XCTAssertEqual(overlayView.currentTool, .counter)
+    }
+
+    func testDeleteLastCounter() {
+        // Add two counters
+        let counter1 = CounterAnnotation(
+            number: 1,
+            position: NSPoint(x: 100, y: 100),
+            color: .systemBlue
+        )
+        let counter2 = CounterAnnotation(
+            number: 2,
+            position: NSPoint(x: 200, y: 200),
+            color: .systemRed
+        )
+
+        overlayView.counterAnnotations = [counter1, counter2]
+        overlayView.nextCounterNumber = 3
+        overlayView.currentTool = .counter
+
+        // Delete last counter
+        overlayView.deleteLastItem()
+
+        // Verify only counter1 remains
+        XCTAssertEqual(overlayView.counterAnnotations.count, 1)
+        XCTAssertEqual(overlayView.counterAnnotations[0].number, 1)
+        XCTAssertEqual(overlayView.nextCounterNumber, 2)
+    }
+
 }

--- a/AnnotateTests/ShortcutManagerTests.swift
+++ b/AnnotateTests/ShortcutManagerTests.swift
@@ -62,4 +62,29 @@ final class ShortcutManagerTests: XCTestCase {
             ShortcutManager.shared.isShortcutTaken("a", excluding: .arrow),
             "Excluding Arrow, 'a' should not be taken")
     }
+
+    func testCounterShortcut() {
+        XCTAssertEqual(
+            ShortcutManager.shared.getShortcut(for: .counter),
+            ShortcutKey.counter.defaultKey,
+            "Default shortcut for Counter should be 'n'"
+        )
+
+        // Set a custom shortcut
+        ShortcutManager.shared.setShortcut("m", for: .counter)
+        XCTAssertEqual(
+            ShortcutManager.shared.getShortcut(for: .counter),
+            "m",
+            "Counter shortcut should be updated to 'm'"
+        )
+
+        // Reset to default
+        ShortcutManager.shared.resetToDefault(tool: .counter)
+        XCTAssertEqual(
+            ShortcutManager.shared.getShortcut(for: .counter),
+            ShortcutKey.counter.defaultKey,
+            "Counter shortcut should be reset to default"
+        )
+    }
+
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## ❓ Why?
 
-Sometimes you need to emphasize a part of your screen or share ideas visually, and Annotate fills that gap with a simple, efficient interface. It enables real-time screen annotations using tools like pen, arrow, highlighter, rectangle, circle, and text—perfect for highlighting and explaining concepts during presentations, live demos, or teaching sessions where visual annotations enhance understanding and clarity.
+Sometimes you need to emphasize a part of your screen or share ideas visually, and Annotate fills that gap with a simple, efficient interface. It enables real-time screen annotations using tools like pen, arrow, highlighter, rectangle, circle, counter, and text—perfect for highlighting and explaining concepts during presentations, live demos, or teaching sessions where visual annotations enhance understanding and clarity.
 
 ## ✨ Features
 
@@ -21,6 +21,7 @@ Sometimes you need to emphasize a part of your screen or share ideas visually, a
   - 🟨 **Highlighter** for emphasizing content.
   - 🔲 **Rectangle** shapes for boxing content.
   - ⭕ **Circle** shapes for highlighting areas.
+  - 🔢 **Counter** tool for adding sequential numbered circles.
   - 📝 **Text** annotations with drag & edit support.
 - ✨ **Fade/Persist Mode:** Control whether annotations fade out after a duration or persist on the screen.
 - 🌈 **Color Picker:** Easily select and persist your preferred color.
@@ -96,6 +97,7 @@ Sometimes you need to emphasize a part of your screen or share ideas visually, a
 | **Rectangle Mode**    | <kbd>r</kbd>                                         | Draw rectangles (hold <kbd>Option</kbd> to expand from center). |
 | **Circle Mode**       | <kbd>o</kbd>                                         | Draw circles (hold <kbd>Option</kbd> to expand from center).    |
 | **Text Mode**         | <kbd>t</kbd>                                         | Add text annotations.                                           |
+| **Counter Mode**      | <kbd>n</kbd>                                         | Add sequential numbered circles.                                |
 | **Finalize Text**     | <kbd>Enter</kbd> or <kbd>Esc</kbd>                   | Finalize text input (empty text removes it).                    |
 | **Toggle Fade Mode**  | <kbd>Space</kbd>                                     | Switch between fade and persist modes.                          |
 | **Delete Last**       | <kbd>Delete</kbd>                                    | Remove the most recent annotation.                              |
@@ -126,5 +128,3 @@ Toggle between two drawing modes:
 
 - <kbd>Delete</kbd>: Removes the most recently added annotation.
 - <kbd>Option</kbd> + <kbd>Delete</kbd>: Clear all annotations from the screen.
-
-


### PR DESCRIPTION
This PR introduces a new counter tool that allows users to add sequential numbered annotations to the screen. The counter tool provides a simple way to mark multiple points of interest with automatically incrementing numbers, making it ideal for step-by-step instructions, highlighting multiple areas in sequence, or creating ordered visual references during presentations.

## Changes

- Implemented a new tool for placing numbered circles (1, 2, 3...) that increment automatically
- Added 'n' key shortcut to quickly access the counter tool
- Incorporated counter tool option into the status bar menu
- Ensured counter annotations properly fade out when in fade mode
- Implemented full undo/redo support for counter operations
- Added counter annotations to the clear all operation
- Implemented proper state management for counter numbers across sessions

## Screenshots

![annotate-counter](https://github.com/user-attachments/assets/8ec94e44-7fb6-44e0-a28d-3860f2490604)



