### PR TITLE
feat: Add keyboard shortcuts to color picker

### DIFF
--- a/Annotate/NSColor+Extensions.swift
+++ b/Annotate/NSColor+Extensions.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+extension NSColor {
+    /// Returns a contrasting color (black or white) based on the brightness of the original color
+    /// - Returns: White for dark colors, black for light colors
+    func contrastingColor() -> NSColor {
+        guard let rgbColor = self.usingColorSpace(.sRGB) else {
+            return .white
+        }
+
+        // Calculate luminance to determine if color is light or dark
+        // based on standard coefficients from the WCAG 2.0 specification
+        let luminance =
+            0.2126 * rgbColor.redComponent + 0.7152 * rgbColor.greenComponent + 0.0722
+            * rgbColor.blueComponent
+
+        return luminance < 0.6 ? .white : .black
+    }
+}

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -470,7 +470,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
         )
         let circlePath = NSBezierPath(ovalIn: circleBounds)
 
-        let backgroundColor = getContrastingColor(for: counter.color)
+        let backgroundColor = counter.color.contrastingColor()
         backgroundColor.withAlphaComponent(0.7 * alpha).setFill()
         circlePath.fill()
 
@@ -726,19 +726,4 @@ class OverlayView: NSView, NSTextFieldDelegate {
             || stillFadingCounters
             || maxPathAge
     }
-}
-
-private func getContrastingColor(for color: NSColor) -> NSColor {
-    guard let rgbColor = color.usingColorSpace(.sRGB) else {
-        return .white
-    }
-
-    // Calculate luminance to determine if color is light or dark
-    // based on standard coefficients from the WCAG 2.0 specification
-    let luminance =
-        0.2126 * rgbColor.redComponent + 0.7152 * rgbColor.greenComponent + 0.0722
-        * rgbColor.blueComponent
-
-    // Return white for dark colors, black for light colors
-    return luminance < 0.6 ? .white : .black
 }

--- a/AnnotateTests/NSColorExtensionsTests.swift
+++ b/AnnotateTests/NSColorExtensionsTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+
+@testable import Annotate
+
+final class NSColorExtensionsTests: XCTestCase {
+
+    // Test that dark colors return white as the contrasting color
+    func testDarkColorsReturnWhiteContrast() {
+        let darkColors: [NSColor] = [
+            .black,
+            .systemBlue,
+            .systemIndigo,
+            .systemPurple,
+            .systemRed,
+            .darkGray,
+            NSColor(calibratedRed: 0.1, green: 0.1, blue: 0.1, alpha: 1.0),
+        ]
+
+        for color in darkColors {
+            let contrastingColor = color.contrastingColor()
+            XCTAssertEqual(
+                contrastingColor, .white, "Dark color \(color) should return white as contrast")
+        }
+    }
+
+    // Test that light colors return black as the contrasting color
+    func testLightColorsReturnBlackContrast() {
+        let lightColors: [NSColor] = [
+            .white,
+            .systemYellow,
+            .systemOrange,
+            .lightGray,
+            NSColor(calibratedRed: 0.9, green: 0.9, blue: 0.9, alpha: 1.0),
+        ]
+
+        for color in lightColors {
+            let contrastingColor = color.contrastingColor()
+            XCTAssertEqual(
+                contrastingColor, .black, "Light color \(color) should return black as contrast")
+        }
+    }
+
+    // Test colors near the threshold (0.6 luminance)
+    func testBorderlineColors() {
+        let justBelowThreshold = NSColor(calibratedRed: 0.5, green: 0.5, blue: 0.5, alpha: 1.0)
+        XCTAssertEqual(justBelowThreshold.contrastingColor(), .white)
+
+        let justAboveThreshold = NSColor(calibratedRed: 0.7, green: 0.7, blue: 0.7, alpha: 1.0)
+        XCTAssertEqual(justAboveThreshold.contrastingColor(), .black)
+    }
+
+    // Test that colors with different alpha values still calculate correct contrast
+    func testColorsWithAlpha() {
+        let transparentBlack = NSColor.black.withAlphaComponent(0.5)
+        let transparentWhite = NSColor.white.withAlphaComponent(0.5)
+
+        // Alpha shouldn't affect the luminance calculation for contrast
+        XCTAssertEqual(transparentBlack.contrastingColor(), .white)
+        XCTAssertEqual(transparentWhite.contrastingColor(), .black)
+    }
+
+    // Test that non-RGB color spaces are handled correctly
+    func testNonRGBColorSpaces() {
+        // Create a color in a different color space
+        let hsbColor = NSColor(hue: 0.5, saturation: 0.8, brightness: 0.3, alpha: 1.0)
+
+        // Should not crash and should return a valid contrasting color
+        XCTAssertNoThrow(hsbColor.contrastingColor())
+        XCTAssertNotNil(hsbColor.contrastingColor())
+    }
+}


### PR DESCRIPTION
This PR enhances the color picker functionality by adding numeric keyboard shortcuts (<kbd>1</kbd>-<kbd>9</kbd>) that allow users to quickly select colors without using the mouse. This improvement streamlines changing colors, making the application more efficient and keyboard-friendly.

## Changes

- Added numeric keyboard shortcuts (<kbd>1</kbd>-<kbd>9</kbd>) for direct color selection in the color picker panel
- Implemented visual indicators on color swatches showing the corresponding shortcut number
- Created automatic contrast adjustment to ensure number visibility against any background color
- Added keyboard event monitoring to capture and process shortcut keypresses
- Extracted contrasting color logic to a reusable NSColor extension for better code organization
