### PR TITLE
feat: Add whiteboard/blackboard background toggle 

### DIFF
--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -466,8 +466,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         UserDefaults.standard.set(!isCurrentlyFadeMode, forKey: UserDefaults.fadeModeKey)
 
         if let menu = statusItem.menu {
-            let currentDrawingModeItem = menu.item(at: 12)
-            let toggleDrawingModeItem = menu.item(at: 13)
+            let currentDrawingModeItem = menu.item(at: 13)
+            let toggleDrawingModeItem = menu.item(at: 14)
 
             currentDrawingModeItem?.title =
                 isCurrentlyFadeMode

--- a/Annotate/BoardManager.swift
+++ b/Annotate/BoardManager.swift
@@ -57,18 +57,18 @@ class BoardManager {
     func adaptColor(_ color: NSColor, forBoardType boardType: BoardView.BoardType) -> NSColor {
         guard isEnabled else { return color }
 
+        if boardType == .blackboard && color.isEqual(NSColor.black) {
+            return NSColor.white
+        } else if boardType == .whiteboard && color.isEqual(NSColor.white) {
+            return NSColor.black
+        }
+
         if boardType == .blackboard && color.contrastingColor() == .white {
-            if color.isEqual(NSColor.black) {
-                return NSColor.white
-            }
-            return color.blended(withFraction: 0.3, of: NSColor.white) ?? color
+            return color.blended(withFraction: 0.1, of: NSColor.white) ?? color
         }
 
         if boardType == .whiteboard && color.contrastingColor() == .black {
-            if color.isEqual(NSColor.white) {
-                return NSColor.black
-            }
-            return color.blended(withFraction: 0.3, of: NSColor.black) ?? color
+            return color.blended(withFraction: 0.1, of: NSColor.black) ?? color
         }
 
         return color

--- a/Annotate/BoardManager.swift
+++ b/Annotate/BoardManager.swift
@@ -30,6 +30,18 @@ class BoardManager {
         return currentBoardType == .blackboard ? "Blackboard" : "Whiteboard"
     }
 
+    var opacity: Double {
+        get {
+            let storedValue = UserDefaults.standard.double(forKey: UserDefaults.boardOpacityKey)
+            return storedValue == 0 ? 0.9 : storedValue.clamped(to: 0.1...1.0)
+        }
+        set {
+            UserDefaults.standard.set(
+                newValue.clamped(to: 0.1...1.0), forKey: UserDefaults.boardOpacityKey)
+            NotificationCenter.default.post(name: .boardAppearanceChanged, object: nil)
+        }
+    }
+
     func toggle() {
         isEnabled = !isEnabled
     }
@@ -66,4 +78,10 @@ class BoardManager {
 extension Notification.Name {
     static let boardStateChanged = Notification.Name("BoardStateChangedNotification")
     static let boardAppearanceChanged = Notification.Name("BoardAppearanceChangedNotification")
+}
+
+extension Comparable {
+    func clamped(to limits: ClosedRange<Self>) -> Self {
+        return min(max(self, limits.lowerBound), limits.upperBound)
+    }
 }

--- a/Annotate/BoardManager.swift
+++ b/Annotate/BoardManager.swift
@@ -1,0 +1,69 @@
+import Cocoa
+
+class BoardManager {
+    static let shared = BoardManager()
+
+    private init() {
+        // Register for system appearance changes
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(systemAppearanceChanged),
+            name: NSNotification.Name("AppleInterfaceThemeChangedNotification"),
+            object: nil
+        )
+    }
+
+    var isEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: UserDefaults.enableBoardKey) }
+        set {
+            UserDefaults.standard.set(newValue, forKey: UserDefaults.enableBoardKey)
+            notifyBoardStateChanged()
+        }
+    }
+
+    var currentBoardType: BoardView.BoardType {
+        let isDarkMode = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        return isDarkMode ? .blackboard : .whiteboard
+    }
+
+    var displayName: String {
+        return currentBoardType == .blackboard ? "Blackboard" : "Whiteboard"
+    }
+
+    func toggle() {
+        isEnabled = !isEnabled
+    }
+
+    @objc func systemAppearanceChanged() {
+        NotificationCenter.default.post(name: .boardAppearanceChanged, object: nil)
+    }
+
+    private func notifyBoardStateChanged() {
+        NotificationCenter.default.post(name: .boardStateChanged, object: nil)
+    }
+
+    func adaptColor(_ color: NSColor, forBoardType boardType: BoardView.BoardType) -> NSColor {
+        guard isEnabled else { return color }
+
+        if boardType == .blackboard && color.contrastingColor() == .white {
+            if color.isEqual(NSColor.black) {
+                return NSColor.white
+            }
+            return color.blended(withFraction: 0.3, of: NSColor.white) ?? color
+        }
+
+        if boardType == .whiteboard && color.contrastingColor() == .black {
+            if color.isEqual(NSColor.white) {
+                return NSColor.black
+            }
+            return color.blended(withFraction: 0.3, of: NSColor.black) ?? color
+        }
+
+        return color
+    }
+}
+
+extension Notification.Name {
+    static let boardStateChanged = Notification.Name("BoardStateChangedNotification")
+    static let boardAppearanceChanged = Notification.Name("BoardAppearanceChangedNotification")
+}

--- a/Annotate/BoardView.swift
+++ b/Annotate/BoardView.swift
@@ -8,9 +8,9 @@ class BoardView: NSView {
         var backgroundColor: NSColor {
             switch self {
             case .whiteboard:
-                return NSColor.white.withAlphaComponent(0.95)
+                return NSColor.white.withAlphaComponent(CGFloat(BoardManager.shared.opacity))
             case .blackboard:
-                return NSColor(calibratedWhite: 0.1, alpha: 0.95)
+                return NSColor(calibratedWhite: 0.1, alpha: CGFloat(BoardManager.shared.opacity))
             }
         }
 

--- a/Annotate/BoardView.swift
+++ b/Annotate/BoardView.swift
@@ -1,0 +1,110 @@
+import Cocoa
+
+class BoardView: NSView {
+    enum BoardType {
+        case whiteboard
+        case blackboard
+
+        var backgroundColor: NSColor {
+            switch self {
+            case .whiteboard:
+                return NSColor.white.withAlphaComponent(0.95)
+            case .blackboard:
+                return NSColor(calibratedWhite: 0.1, alpha: 0.95)
+            }
+        }
+
+        var borderColor: NSColor {
+            switch self {
+            case .whiteboard:
+                return NSColor.lightGray
+            case .blackboard:
+                return NSColor.darkGray
+            }
+        }
+    }
+
+    private var boardType: BoardType = .whiteboard
+    private var currentAppearance: NSAppearance?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        wantsLayer = true
+        layer?.cornerRadius = 8
+        layer?.masksToBounds = true
+        layer?.borderWidth = 1
+
+        updateForAppearance()
+
+        // Register for system appearance changes
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(appearanceDidChange),
+            name: NSNotification.Name("AppleInterfaceThemeChangedNotification"),
+            object: nil
+        )
+    }
+
+    deinit {
+        DistributedNotificationCenter.default().removeObserver(self)
+    }
+
+    @objc private func appearanceDidChange() {
+        updateForAppearance()
+    }
+
+    private func updateForAppearance() {
+        let newAppearance = self.effectiveAppearance
+
+        let isDarkMode = newAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        boardType = isDarkMode ? .blackboard : .whiteboard
+
+        layer?.backgroundColor = boardType.backgroundColor.cgColor
+        layer?.borderColor = boardType.borderColor.cgColor
+
+        needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateForAppearance()
+    }
+
+    func getCurrentBoardType() -> BoardType {
+        return boardType
+    }
+
+    override var isHidden: Bool {
+        didSet {
+            if !isHidden && oldValue {
+                alphaValue = 0
+                NSAnimationContext.runAnimationGroup { context in
+                    context.duration = 0.3
+                    self.animator().alphaValue = 1
+                }
+            } else if isHidden && !oldValue {
+                NSAnimationContext.runAnimationGroup({ context in
+                    context.duration = 0.3
+                    self.animator().alphaValue = 0
+                }) {
+                    super.isHidden = true
+                }
+                return
+            }
+            super.isHidden = isHidden
+        }
+    }
+}

--- a/Annotate/Constants.swift
+++ b/Annotate/Constants.swift
@@ -9,4 +9,5 @@ extension UserDefaults {
     static let clearDrawingsOnStartKey = "ClearDrawingsOnStart"
     static let hideDockIconKey = "HideDockIcon"
     static let fadeModeKey = "FadeMode"
+    static let enableBoardKey = "EnableBoard"
 }

--- a/Annotate/Constants.swift
+++ b/Annotate/Constants.swift
@@ -10,4 +10,5 @@ extension UserDefaults {
     static let hideDockIconKey = "HideDockIcon"
     static let fadeModeKey = "FadeMode"
     static let enableBoardKey = "EnableBoard"
+    static let boardOpacityKey = "BoardOpacity"
 }

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -750,30 +750,11 @@ class OverlayView: NSView, NSTextFieldDelegate {
     }
 
     func adaptColorForBoard(_ color: NSColor, boardType: BoardView.BoardType) -> NSColor {
-        guard adaptColorsToBoardType else { return color }
-
-        if boardType == .blackboard && color.contrastingColor() == .white {
-            if color.isEqual(NSColor.black) {
-                return NSColor.white
-            }
-            return color.blended(withFraction: 0.1, of: NSColor.white) ?? color
-        }
-
-        if boardType == .whiteboard && color.contrastingColor() == .black {
-            if color.isEqual(NSColor.white) {
-                return NSColor.black
-            }
-            return color.blended(withFraction: 0.1, of: NSColor.black) ?? color
-        }
-
-        return color
+        return BoardManager.shared.adaptColor(color, forBoardType: boardType)
     }
 
     var currentBoardType: BoardView.BoardType {
-        if let window = self.window as? OverlayWindow {
-            return window.boardView.getCurrentBoardType()
-        }
-        return .whiteboard
+        return BoardManager.shared.currentBoardType
     }
 
     func updateAdaptColors(boardEnabled: Bool) {

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -1,6 +1,8 @@
 import Cocoa
 
 class OverlayView: NSView, NSTextFieldDelegate {
+    var adaptColorsToBoardType: Bool = true
+
     var arrows: [Arrow] = []
     var currentArrow: Arrow?
 
@@ -361,6 +363,8 @@ class OverlayView: NSView, NSTextFieldDelegate {
     }
 
     private func drawArrow(from start: NSPoint, to end: NSPoint, color: NSColor) {
+        let adaptedColor = adaptColorForBoard(color, boardType: currentBoardType)
+
         let path = NSBezierPath()
         path.move(to: start)
         path.line(to: end)
@@ -387,12 +391,14 @@ class OverlayView: NSView, NSTextFieldDelegate {
         path.move(to: end)
         path.line(to: p2)
 
-        color.setStroke()
+        adaptedColor.setStroke()
         path.lineWidth = 3.0
         path.stroke()
     }
 
     private func drawRectangle(_ rectangle: Rectangle, alpha: CGFloat) {
+        let adaptedColor = adaptColorForBoard(rectangle.color, boardType: currentBoardType)
+
         let rect = NSRect(
             x: min(rectangle.startPoint.x, rectangle.endPoint.x),
             y: min(rectangle.startPoint.y, rectangle.endPoint.y),
@@ -401,12 +407,14 @@ class OverlayView: NSView, NSTextFieldDelegate {
         )
 
         let path = NSBezierPath(rect: rect)
-        rectangle.color.withAlphaComponent(alpha).setStroke()
+        adaptedColor.withAlphaComponent(alpha).setStroke()
         path.lineWidth = 3.0
         path.stroke()
     }
 
     private func drawCircle(_ circle: Circle, alpha: CGFloat) {
+        let adaptedColor = adaptColorForBoard(circle.color, boardType: currentBoardType)
+
         let rect = NSRect(
             x: min(circle.startPoint.x, circle.endPoint.x),
             y: min(circle.startPoint.y, circle.endPoint.y),
@@ -415,7 +423,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
         )
 
         let path = NSBezierPath(ovalIn: rect)
-        circle.color.withAlphaComponent(alpha).setStroke()
+        adaptedColor.withAlphaComponent(alpha).setStroke()
         path.lineWidth = 3.0
         path.stroke()
     }
@@ -429,6 +437,8 @@ class OverlayView: NSView, NSTextFieldDelegate {
     private func drawPath(_ path: DrawingPath, tool: ToolType) {
         guard !path.points.isEmpty else { return }
 
+        let adaptedColor = adaptColorForBoard(path.color, boardType: currentBoardType)
+
         let bezierPath = NSBezierPath()
         bezierPath.move(to: path.points[0].point)
 
@@ -437,10 +447,10 @@ class OverlayView: NSView, NSTextFieldDelegate {
         }
 
         if tool == .highlighter {
-            path.color.withAlphaComponent(0.5).setStroke()
+            adaptedColor.withAlphaComponent(0.5).setStroke()
             bezierPath.lineWidth = 14.0
         } else {
-            path.color.setStroke()
+            adaptedColor.setStroke()
             bezierPath.lineWidth = 3.0
         }
 
@@ -450,8 +460,10 @@ class OverlayView: NSView, NSTextFieldDelegate {
     }
 
     private func drawText(_ annotation: TextAnnotation) {
+        let adaptedColor = adaptColorForBoard(annotation.color, boardType: currentBoardType)
+
         let attributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: annotation.color,
+            .foregroundColor: adaptedColor,
             .font: NSFont.systemFont(ofSize: annotation.fontSize),
         ]
         let attributedString = NSAttributedString(string: annotation.text, attributes: attributes)
@@ -459,6 +471,8 @@ class OverlayView: NSView, NSTextFieldDelegate {
     }
 
     private func drawCounter(_ counter: CounterAnnotation, alpha: CGFloat) {
+        let adaptedColor = adaptColorForBoard(counter.color, boardType: currentBoardType)
+
         let radius: CGFloat = 15.0
         let diameter = radius * 2
 
@@ -470,11 +484,11 @@ class OverlayView: NSView, NSTextFieldDelegate {
         )
         let circlePath = NSBezierPath(ovalIn: circleBounds)
 
-        let backgroundColor = counter.color.contrastingColor()
+        let backgroundColor = adaptedColor.contrastingColor()
         backgroundColor.withAlphaComponent(0.7 * alpha).setFill()
         circlePath.fill()
 
-        counter.color.withAlphaComponent(alpha).setStroke()
+        adaptedColor.withAlphaComponent(alpha).setStroke()
         circlePath.lineWidth = 2.5
         circlePath.stroke()
 
@@ -483,7 +497,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
         paragraphStyle.alignment = .center
         let fontSize: CGFloat = 14.0
         let attributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: counter.color.withAlphaComponent(alpha),
+            .foregroundColor: adaptedColor.withAlphaComponent(alpha),
             .font: NSFont.systemFont(ofSize: fontSize, weight: .heavy),
             .paragraphStyle: paragraphStyle,
         ]
@@ -586,13 +600,21 @@ class OverlayView: NSView, NSTextFieldDelegate {
             frame: NSRect(x: point.x, y: point.y, width: width, height: 24))
         if let textField = activeTextField {
             textField.font = NSFont.systemFont(ofSize: 18)
-            textField.backgroundColor = .clear
+
+            let boardType = currentBoardType
+            if boardType == .blackboard {
+                textField.backgroundColor = NSColor.black.withAlphaComponent(0.3)
+                textField.textColor = adaptColorForBoard(currentColor, boardType: boardType)
+            } else {
+                textField.backgroundColor = NSColor.white.withAlphaComponent(0.3)
+                textField.textColor = adaptColorForBoard(currentColor, boardType: boardType)
+            }
+
             textField.isBordered = false
-            textField.textColor = currentColor
             textField.isEditable = true
             textField.isSelectable = true
             textField.isBezeled = false
-            textField.drawsBackground = false
+            textField.drawsBackground = true
             textField.usesSingleLineMode = false
             textField.cell?.wraps = false
             textField.cell?.truncatesLastVisibleLine = false
@@ -725,5 +747,37 @@ class OverlayView: NSView, NSTextFieldDelegate {
             || stillFadingCircles
             || stillFadingCounters
             || maxPathAge
+    }
+
+    func adaptColorForBoard(_ color: NSColor, boardType: BoardView.BoardType) -> NSColor {
+        guard adaptColorsToBoardType else { return color }
+
+        if boardType == .blackboard && color.contrastingColor() == .white {
+            if color.isEqual(NSColor.black) {
+                return NSColor.white
+            }
+            return color.blended(withFraction: 0.1, of: NSColor.white) ?? color
+        }
+
+        if boardType == .whiteboard && color.contrastingColor() == .black {
+            if color.isEqual(NSColor.white) {
+                return NSColor.black
+            }
+            return color.blended(withFraction: 0.1, of: NSColor.black) ?? color
+        }
+
+        return color
+    }
+
+    var currentBoardType: BoardView.BoardType {
+        if let window = self.window as? OverlayWindow {
+            return window.boardView.getCurrentBoardType()
+        }
+        return .whiteboard
+    }
+
+    func updateAdaptColors(boardEnabled: Bool) {
+        adaptColorsToBoardType = boardEnabled
+        needsDisplay = true
     }
 }

--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -56,6 +56,7 @@ class OverlayWindow: NSWindow {
             height: windowRect.height
         )
         boardView = BoardView(frame: boardFrame)
+        boardView.isHidden = !BoardManager.shared.isEnabled
         containerView.addSubview(boardView)
 
         overlayView = OverlayView(frame: containerView.bounds)

--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -2,6 +2,8 @@ import Cocoa
 
 class OverlayWindow: NSWindow {
     var overlayView: OverlayView!
+    var boardView: BoardView!
+
     var anchorPoint: NSPoint = .zero
     private var isOptionCurrentlyPressed = false
     private var wasOptionPressedOnMouseDown = false
@@ -47,11 +49,14 @@ class OverlayWindow: NSWindow {
 
         let containerView = NSView(frame: NSRect(origin: .zero, size: windowRect.size))
 
-        let visualEffect = NSVisualEffectView(frame: containerView.bounds)
-        visualEffect.material = .fullScreenUI
-        visualEffect.state = .active
-        visualEffect.alphaValue = 0
-        containerView.addSubview(visualEffect)
+        let boardFrame = NSRect(
+            x: 0,
+            y: 0,
+            width: windowRect.width,
+            height: windowRect.height
+        )
+        boardView = BoardView(frame: boardFrame)
+        containerView.addSubview(boardView)
 
         overlayView = OverlayView(frame: containerView.bounds)
         overlayView.wantsLayer = true
@@ -378,6 +383,9 @@ class OverlayWindow: NSWindow {
                 return
             case ShortcutManager.shared.getShortcut(for: .colorPicker):
                 AppDelegate.shared?.showColorPicker(nil)
+                return
+            case ShortcutManager.shared.getShortcut(for: .toggleBoard):
+                AppDelegate.shared?.toggleBoardVisibility(nil)
                 return
             default:
                 break

--- a/Annotate/SettingsView.swift
+++ b/Annotate/SettingsView.swift
@@ -8,6 +8,7 @@ struct SettingsView: View {
     private var hideDockIcon = false
     @State private var shortcuts: [ShortcutKey: String] = ShortcutManager.shared.allShortcuts
     @State private var editingShortcut: ShortcutKey?
+    @State private var boardOpacity: Double = BoardManager.shared.opacity
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -16,6 +17,13 @@ struct SettingsView: View {
                     KeyboardShortcuts.Recorder("Annotate Hotkey:", name: .toggleOverlay)
 
                     Divider()
+
+                    Slider(value: $boardOpacity, in: 0.1...1.0) {
+                        Text("Board Opacity: \(Int(boardOpacity * 100))%")
+                    }
+                    .onChange(of: boardOpacity) { oldValue, newValue in
+                        BoardManager.shared.opacity = newValue
+                    }
 
                     Toggle("Clear Drawings on Toggle", isOn: $clearDrawingsOnStart)
                         .toggleStyle(.checkbox)

--- a/Annotate/ShortcutManager.swift
+++ b/Annotate/ShortcutManager.swift
@@ -9,6 +9,7 @@ enum ShortcutKey: String, CaseIterable {
     case counter = "n"
     case text = "t"
     case colorPicker = "c"
+    case toggleBoard = "b"
 
     var defaultKey: String { rawValue }
 
@@ -22,6 +23,7 @@ enum ShortcutKey: String, CaseIterable {
         case .counter: return "Counter"
         case .text: return "Text"
         case .colorPicker: return "Color Picker"
+        case .toggleBoard: return "Toggle Board"
         }
     }
 }

--- a/AnnotateTests/AppDelegateTests.swift
+++ b/AnnotateTests/AppDelegateTests.swift
@@ -224,4 +224,43 @@ final class AppDelegateTests: XCTestCase {
                 "Overlay window should restore persisted fade mode as false.")
         }
     }
+
+    func testToggleBoardVisibility() {
+        let initialState = UserDefaults.standard.bool(forKey: UserDefaults.enableBoardKey)
+
+        appDelegate.toggleBoardVisibility(nil)
+
+        let newState = UserDefaults.standard.bool(forKey: UserDefaults.enableBoardKey)
+        XCTAssertNotEqual(initialState, newState, "Board visibility should be toggled")
+
+        appDelegate.toggleBoardVisibility(nil)
+        let finalState = UserDefaults.standard.bool(forKey: UserDefaults.enableBoardKey)
+        XCTAssertEqual(
+            initialState, finalState, "Board visibility should be toggled back to original state")
+    }
+
+    func testUpdateBoardMenuItems() {
+        guard let menu = appDelegate.statusItem.menu else {
+            XCTFail("Status bar menu not initialized")
+            return
+        }
+
+        let toggleBoardItem = menu.items.first {
+            $0.action == #selector(AppDelegate.toggleBoardVisibility(_:))
+        }
+        XCTAssertNotNil(toggleBoardItem, "Board toggle menu item should exist")
+
+        let initialTitle = toggleBoardItem?.title
+
+        let initialState = BoardManager.shared.isEnabled
+        BoardManager.shared.isEnabled = !initialState
+
+        appDelegate.updateBoardMenuItems()
+
+        let newTitle = toggleBoardItem?.title
+        XCTAssertNotEqual(
+            initialTitle, newTitle, "Menu item title should change when board visibility changes")
+
+        BoardManager.shared.isEnabled = initialState
+    }
 }

--- a/AnnotateTests/BoardManagerTests.swift
+++ b/AnnotateTests/BoardManagerTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+@testable import Annotate
+
+final class BoardManagerTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: UserDefaults.enableBoardKey)
+        UserDefaults.standard.removeObject(forKey: UserDefaults.boardOpacityKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: UserDefaults.enableBoardKey)
+        UserDefaults.standard.removeObject(forKey: UserDefaults.boardOpacityKey)
+        super.tearDown()
+    }
+
+    func testBoardManagerInitialization() {
+        XCTAssertFalse(BoardManager.shared.isEnabled, "Board should be disabled by default")
+
+        let defaultOpacity = BoardManager.shared.opacity
+        XCTAssertEqual(defaultOpacity, 0.9, "Default opacity should be 0.9")
+    }
+
+    func testBoardToggle() {
+        XCTAssertFalse(BoardManager.shared.isEnabled, "Board should start disabled")
+
+        BoardManager.shared.toggle()
+        XCTAssertTrue(BoardManager.shared.isEnabled, "Board should be enabled after toggle")
+
+        BoardManager.shared.toggle()
+        XCTAssertFalse(
+            BoardManager.shared.isEnabled, "Board should be disabled after second toggle")
+    }
+
+    func testOpacitySetting() {
+        let testOpacity = 0.5
+        BoardManager.shared.opacity = testOpacity
+        XCTAssertEqual(BoardManager.shared.opacity, testOpacity, "Opacity should be updated to 0.5")
+
+        let persistedOpacity = UserDefaults.standard.double(forKey: UserDefaults.boardOpacityKey)
+        XCTAssertEqual(persistedOpacity, testOpacity, "Opacity should be persisted to UserDefaults")
+    }
+
+    func testOpacityClamping() {
+        BoardManager.shared.opacity = 1.5  // Above max
+        XCTAssertEqual(BoardManager.shared.opacity, 1.0, "Opacity should be clamped to 1.0 maximum")
+
+        BoardManager.shared.opacity = 0.05  // Below min
+        XCTAssertEqual(BoardManager.shared.opacity, 0.1, "Opacity should be clamped to 0.1 minimum")
+
+        BoardManager.shared.opacity = 0.75  // Valid value
+        XCTAssertEqual(BoardManager.shared.opacity, 0.75, "Valid opacity should be set correctly")
+    }
+}

--- a/AnnotateTests/BoardViewTests.swift
+++ b/AnnotateTests/BoardViewTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+@testable import Annotate
+
+final class BoardViewTests: XCTestCase {
+    var boardView: BoardView!
+
+    override func setUp() {
+        super.setUp()
+        boardView = BoardView(frame: NSRect(x: 0, y: 0, width: 500, height: 500))
+    }
+
+    override func tearDown() {
+        boardView = nil
+        super.tearDown()
+    }
+
+    func testBoardViewInitialization() {
+        XCTAssertTrue(boardView.wantsLayer, "BoardView should have wantsLayer set to true")
+        XCTAssertNotNil(boardView.layer, "BoardView should have a layer")
+        XCTAssertEqual(boardView.layer?.cornerRadius, 8, "BoardView should have rounded corners")
+        XCTAssertTrue(boardView.layer?.masksToBounds ?? false, "BoardView should mask to bounds")
+        XCTAssertEqual(boardView.layer?.borderWidth, 1, "BoardView should have a border")
+    }
+
+    func testBoardBackgroundColor() {
+        let backgroundColor = boardView.layer?.backgroundColor
+
+        XCTAssertNotNil(backgroundColor, "Background color should be set")
+
+        let originalOpacity = BoardManager.shared.opacity
+        BoardManager.shared.opacity = 0.5
+
+        boardView.updateForAppearance()
+
+        let newBackgroundColor = boardView.layer?.backgroundColor
+        XCTAssertNotEqual(
+            backgroundColor, newBackgroundColor, "Background color should change with opacity")
+
+        BoardManager.shared.opacity = originalOpacity
+    }
+
+    func testVisibilityChangeNotification() {
+        BoardManager.shared.isEnabled = !BoardManager.shared.isEnabled
+
+        NotificationCenter.default.post(name: .boardStateChanged, object: nil)
+
+        XCTAssertEqual(
+            boardView.isHidden, !BoardManager.shared.isEnabled,
+            "BoardView hidden state should match !isEnabled")
+
+        BoardManager.shared.isEnabled = !BoardManager.shared.isEnabled
+    }
+}

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -137,4 +137,15 @@ final class OverlayViewTests: XCTestCase {
         XCTAssertEqual(overlayView.nextCounterNumber, 2)
     }
 
+    func testUpdateAdaptColors() {
+        overlayView.updateAdaptColors(boardEnabled: true)
+        XCTAssertTrue(
+            overlayView.adaptColorsToBoardType, "adaptColorsToBoardType should be true when enabled"
+        )
+
+        overlayView.updateAdaptColors(boardEnabled: false)
+        XCTAssertFalse(
+            overlayView.adaptColorsToBoardType,
+            "adaptColorsToBoardType should be false when disabled")
+    }
 }

--- a/AnnotateTests/OverlayWindowTests.swift
+++ b/AnnotateTests/OverlayWindowTests.swift
@@ -31,13 +31,6 @@ final class OverlayWindowTests: XCTestCase {
         // Test view hierarchy
         XCTAssertNotNil(window.contentView)
         XCTAssertNotNil(window.overlayView)
-
-        // Test visual effect view
-        let visualEffectView = window.contentView?.subviews.first as? NSVisualEffectView
-        XCTAssertNotNil(visualEffectView)
-        XCTAssertEqual(visualEffectView?.material, .fullScreenUI)
-        XCTAssertEqual(visualEffectView?.state, .active)
-        XCTAssertEqual(visualEffectView?.alphaValue, 0)
     }
 
     func testFadeLoop() {


### PR DESCRIPTION
This PR adds a new whiteboard/blackboard background feature to Annotate, providing users with a more natural drawing experience that adapts to their system appearance preferences. 

## Features

### Whiteboard/Blackboard Toggle
- **Automatic Theme Detection**: Automatically uses whiteboard in light mode and blackboard in dark mode
- **Smart Color Adaptation**: Automatically adjusts drawing colors for optimal visibility on different backgrounds
- **Keyboard Shortcut**: Press 'b' to quickly toggle the board on/off
- **Smooth Animations**: Elegant fade transitions when showing/hiding the board
- **Persistent State**: Board visibility state is remembered between app launches
- **Menu Integration**: Dynamic menu labels that update based on current appearance

### Opacity Control
- **Adjustable Transparency**: Slider in settings to control board opacity from 10% to 100%
- **Persistent Settings**: Opacity value is saved in UserDefaults
- **Real-time Updates**: Changes are applied immediately to all board instances

## Screenshots

[annotate-board.webm](https://github.com/user-attachments/assets/9dd71698-cc0a-48ba-a015-4a0402f5bf2b)


