### PR TITLE
Fix: Reset color picker popover reference to enable repeated usage

### DIFF
--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -334,11 +334,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
         overlayWindows.values.forEach { window in
             window.overlayView.currentTool = tool
         }
+        showOverlay()
     }
 
     @objc func enableArrowMode(_ sender: NSMenuItem) {
         switchTool(to: .arrow)
-        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Arrow"
@@ -347,7 +347,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
 
     @objc func enableLineMode(_ sender: NSMenuItem) {
         switchTool(to: .line)
-        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Line"
@@ -356,7 +355,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
 
     @objc func enablePenMode(_ sender: NSMenuItem) {
         switchTool(to: .pen)
-        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Pen"
@@ -365,7 +363,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
 
     @objc func enableHighlighterMode(_ sender: NSMenuItem) {
         switchTool(to: .highlighter)
-        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Highlighter"
@@ -374,7 +371,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
 
     @objc func enableRectangleMode(_ sender: NSMenuItem) {
         switchTool(to: .rectangle)
-        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Rectangle"
@@ -383,7 +379,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
 
     @objc func enableCircleMode(_ sender: NSMenuItem) {
         switchTool(to: .circle)
-        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Circle"
@@ -392,7 +387,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
 
     @objc func enableCounterMode(_ sender: NSMenuItem) {
         switchTool(to: .counter)
-        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Counter"
@@ -401,7 +395,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
 
     @objc func enableTextMode(_ sender: NSMenuItem) {
         switchTool(to: .text)
-        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Text"
@@ -411,7 +404,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
     @objc func toggleBoardVisibility(_ sender: Any?) {
         BoardManager.shared.toggle()
         updateBoardMenuItems()
-        showOverlay()
     }
 
     func updateBoardMenuItems() {

--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -3,11 +3,11 @@ import Cocoa
 import SwiftUI
 
 @MainActor
-class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverDelegate {
     static weak var shared: AppDelegate?
 
     var statusItem: NSStatusItem!
-    var colorPopover: NSPopover!
+    var colorPopover: NSPopover?
     var currentColor: NSColor = .systemRed
     var hotkeyMonitor: Any?
     var overlayWindows: [NSScreen: OverlayWindow] = [:]
@@ -260,17 +260,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     @objc func showColorPicker(_ sender: Any?) {
         if colorPopover == nil {
             colorPopover = NSPopover()
-            colorPopover.contentViewController = ColorPickerViewController()
-            colorPopover.behavior = .transient
+            colorPopover?.contentViewController = ColorPickerViewController()
+            colorPopover?.behavior = .transient
+            colorPopover?.delegate = self
         }
 
         if let button = statusItem.button {
-            colorPopover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            colorPopover?.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
 
-            if let popoverWindow = colorPopover.contentViewController?.view.window {
+            if let popoverWindow = colorPopover?.contentViewController?.view.window {
                 popoverWindow.level = .popUpMenu
             }
         }
+    }
+
+    func popoverWillClose(_ notification: Notification) {
+        colorPopover = nil
     }
 
     @objc func toggleOverlay() {
@@ -329,11 +334,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         overlayWindows.values.forEach { window in
             window.overlayView.currentTool = tool
         }
-        showOverlay()
     }
 
     @objc func enableArrowMode(_ sender: NSMenuItem) {
         switchTool(to: .arrow)
+        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Arrow"
@@ -342,6 +347,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @objc func enableLineMode(_ sender: NSMenuItem) {
         switchTool(to: .line)
+        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Line"
@@ -350,6 +356,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @objc func enablePenMode(_ sender: NSMenuItem) {
         switchTool(to: .pen)
+        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Pen"
@@ -358,6 +365,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @objc func enableHighlighterMode(_ sender: NSMenuItem) {
         switchTool(to: .highlighter)
+        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Highlighter"
@@ -366,6 +374,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @objc func enableRectangleMode(_ sender: NSMenuItem) {
         switchTool(to: .rectangle)
+        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Rectangle"
@@ -374,6 +383,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @objc func enableCircleMode(_ sender: NSMenuItem) {
         switchTool(to: .circle)
+        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Circle"
@@ -382,6 +392,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @objc func enableCounterMode(_ sender: NSMenuItem) {
         switchTool(to: .counter)
+        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Counter"
@@ -390,6 +401,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     @objc func enableTextMode(_ sender: NSMenuItem) {
         switchTool(to: .text)
+        showOverlay()
         if let menu = statusItem.menu {
             let currentToolItem = menu.item(at: 2)
             currentToolItem?.title = "Current Tool: Text"

--- a/Annotate/ColorPickerViewController.swift
+++ b/Annotate/ColorPickerViewController.swift
@@ -165,8 +165,8 @@ class ColorPickerViewController: NSViewController {
         appDelegate.updateStatusBarIcon(with: selectedColor)
 
         // Close the popover
-        if let presentingPopover = self.view.window?.parent?.contentViewController as? NSPopover {
-            presentingPopover.close()
+        if let popover = AppDelegate.shared?.colorPopover {
+            popover.performClose(nil)
         } else if let parentWindow = self.view.window {
             parentWindow.close()
         }


### PR DESCRIPTION
### Summary
Fixes issue #9, where the color picker becomes unresponsive and cannot be reopened after the first use.

### Problem
The color picker popover was only working once per app session. After selecting a color and closing the popover, subsequent attempts to open it (via shortcut key or menu) would fail silently. This was caused by the app retaining a stale reference to the closed popover instance.

### Root Cause
The `colorPopover` property was never reset to `nil` after the popover closed
When `showColorPicker` was called again, it would try to show the existing (but closed) popover instead of creating a fresh one
This left the color picker in an unusable state

### Solution
Made `AppDelegate` conform to `NSPopoverDelegate`
Implemented `popoverWillClose(_:)` to reset `colorPopover = nil` when the popover closes
Updated `ColorPickerViewController` to close the popover via `performClose(nil)` properly
Made `colorPopover` optional (NSPopover?) for better type safety

### Testing

- [x]  Color picker opens on first use
- [x]  Color picker can be reopened multiple times after closing
- [x]  Works with both menu selection and keyboard shortcut
- [x]  Color selection and application still works correctly
- [x]  No memory leaks or retained references

---
Resolves #9 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Color picker popover now closes reliably, reducing flicker and preventing occasional crashes.
  * Safer handling of the color picker improves interaction stability.

* **Refactor**
  * Improved popover lifecycle management for better stability.
  * Adjusted board toggle behavior so overlay visibility timing is more predictable when toggling the board.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->