### PR TITLE
feat(ci): Add automated macOS release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Release (macOS)
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-sign-notarize-release:
+    name: Build → Sign → Notarize → Release
+    runs-on: macos-15
+    environment: release
+    env:
+      APP_NAME: Annotate
+      SCHEME: Annotate
+      CONFIG: Release
+      ARCHIVE_PATH: build/Annotate.xcarchive
+      EXPORT_DIR: build/export
+      EXPORT_PLIST: packaging/ExportOptions.plist
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve tag version
+        id: version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "semver=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Inject TEAM_ID into ExportOptions
+        run: |
+          sed "s/__TEAM_ID__/${{ secrets.TEAM_ID }}/" "$EXPORT_PLIST" > "$EXPORT_PLIST.out"
+          mv "$EXPORT_PLIST.out" "$EXPORT_PLIST"
+
+      - name: Import Developer ID certificate
+        uses: apple-actions/import-codesign-certs@v5
+        with:
+          p12-file-base64: ${{ secrets.MACOS_CERT_BASE64 }}
+          p12-password: ${{ secrets.MACOS_CERT_PASSWORD }}
+
+      - name: Update marketing version from tag
+        run: |
+          # Update marketing version in project settings
+          /usr/libexec/PlistBuddy -c "Set :objects:$(plutil -extract objects json Annotate.xcodeproj/project.pbxproj | jq -r 'to_entries[] | select(.value.isa == "XCBuildConfiguration" and (.value.name == "Release" or .value.name == "Debug")) | .key' | head -1):buildSettings:MARKETING_VERSION ${{ steps.version.outputs.semver }}" Annotate.xcodeproj/project.pbxproj || true
+
+      - name: Install xcpretty
+        run: gem install xcpretty --no-document
+
+      - name: Xcode archive (arm64, verbose, unsigned)
+        run: |
+          set -euxo pipefail
+          mkdir -p build
+          ENTRY="-project Annotate.xcodeproj"
+          xcodebuild \
+            $ENTRY \
+            -scheme "$SCHEME" \
+            -configuration "$CONFIG" \
+            -archivePath "$ARCHIVE_PATH" \
+            -destination "generic/platform=macOS" \
+            ARCHS=arm64 \
+            CODE_SIGNING_ALLOWED=NO \
+            clean archive | xcpretty && exit ${PIPESTATUS[0]}
+
+      - name: Export signed app (Developer ID)
+        run: |
+          mkdir -p "$EXPORT_DIR"
+          xcodebuild -exportArchive \
+            -archivePath "$ARCHIVE_PATH" \
+            -exportPath "$EXPORT_DIR" \
+            -exportOptionsPlist "$EXPORT_PLIST" | xcpretty && exit ${PIPESTATUS[0]}
+
+      - name: Re-sign with hardened runtime
+        run: |
+          codesign --force --sign "Developer ID Application" \
+            -o runtime --timestamp \
+            --entitlements "$APP_NAME/$APP_NAME.entitlements" \
+            "$EXPORT_DIR/$APP_NAME.app"
+
+      - name: Package DMG
+        run: |
+          chmod +x packaging/make_dmg.sh
+          DMG_PATH=$(./packaging/make_dmg.sh)
+          echo "DMG_PATH=$DMG_PATH" >> $GITHUB_ENV
+
+      - name: Notarize (notarytool --wait)
+        run: |
+          xcrun notarytool submit "$DMG_PATH" \
+            --apple-id "${{ secrets.NOTARIZE_APPLE_ID }}" \
+            --password "${{ secrets.NOTARIZE_PASSWORD }}" \
+            --team-id "${{ secrets.TEAM_ID }}" \
+            --wait
+
+      - name: Validate & staple for distribution
+        run: |
+          echo "Verifying app signature and entitlements..."
+          codesign --verify --deep --strict --verbose=2 "$EXPORT_DIR/$APP_NAME.app"
+          spctl -a -vvv --type exec "$EXPORT_DIR/$APP_NAME.app"
+
+          echo "Stapling notarization ticket to DMG..."
+          xcrun stapler staple "$DMG_PATH"
+          xcrun stapler validate "$DMG_PATH"
+
+      - name: Create GitHub Release & upload DMG
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Annotate ${{ github.ref_name }}"
+          draft: false
+          prerelease: false
+          files: |
+            ${{ env.DMG_PATH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/Annotate/Annotate.entitlements
+++ b/Annotate/Annotate.entitlements
@@ -6,5 +6,13 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<false/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<false/>
+	<key>com.apple.security.cs.disable-executable-page-protection</key>
+	<false/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<false/>
 </dict>
 </plist>

--- a/packaging/ExportOptions.plist
+++ b/packaging/ExportOptions.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key>
+  <string>developer-id</string>
+  <key>destination</key>
+  <string>export</string>
+  <key>teamID</key>
+  <string>__TEAM_ID__</string>
+  <key>signingStyle</key>
+  <string>automatic</string>
+  <key>stripSwiftSymbols</key>
+  <true/>
+  <key>uploadSymbols</key>
+  <true/>
+</dict>
+</plist>

--- a/packaging/make_dmg.sh
+++ b/packaging/make_dmg.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+APP_NAME="Annotate"
+PRODUCT_DIR="build/export"
+APP_PATH="$PRODUCT_DIR/$APP_NAME.app"
+DMG_NAME="$APP_NAME.dmg"
+DMG_OUT="build/$DMG_NAME"
+
+rm -f "$DMG_OUT"
+command -v create-dmg >/dev/null 2>&1 || npm i -g create-dmg 1>&2
+
+create-dmg \
+  --overwrite \
+  --dmg-title "$APP_NAME" \
+  --icon-size 128 \
+  "$APP_PATH" \
+  "$(dirname "$DMG_OUT")" 1>&2
+
+mv "$(dirname "$DMG_OUT")"/"$APP_NAME"*.dmg "$DMG_OUT" 1>&2
+
+echo "$DMG_OUT"


### PR DESCRIPTION
## Overview
This PR introduces a complete CI/CD pipeline for automated macOS releases, enabling seamless distribution of signed and notarized Annotate builds through GitHub Releases.

## Motivation
Currently, macOS releases require manual building, code signing, notarization, and packaging - a time-consuming and error-prone process. This automation:
- Eliminates manual release steps and potential human errors
- Ensures consistent, reproducible builds for every release
- Provides proper code signing and notarization for macOS security compliance
- Streamlines the release process to a simple git tag push

## Changes

### 🔄 GitHub Actions Workflow (`.github/workflows/release.yml`)
- **Trigger**: Automated on version tag pushes (`v*`)
- **Build Process**: Xcode archive with arm64 architecture targeting macOS 15
- **Code Signing**: Developer ID Application certificate integration
- **Notarization**: Full Apple notarization with notarytool
- **Distribution**: Automated DMG creation and GitHub Release publishing
- **Security**: Hardened runtime with proper entitlements enforcement

### 🔒 Security Hardening (`Annotate/Annotate.entitlements`)
Added hardened runtime entitlements for enhanced security:
- `com.apple.security.cs.allow-jit`: `false` (disabled JIT compilation)
- `com.apple.security.cs.allow-unsigned-executable-memory`: `false`
- `com.apple.security.cs.disable-executable-page-protection`: `false`
- `com.apple.security.cs.disable-library-validation`: `false`

### ⚙️ Export Configuration (`packaging/ExportOptions.plist`)
- Developer ID distribution method for outside App Store releases
- Automatic signing style with team ID templating
- Symbol stripping and upload configuration for optimization

### 📦 DMG Packaging (`packaging/make_dmg.sh`)
- Automated DMG creation using `create-dmg` npm package
- Configurable app name and build paths
- Auto-installation of dependencies if missing

## Breaking Changes
None - this is purely additive CI/CD infrastructure.

## 🧪 Testing

To test the workflow:
1. Configure required repository secrets in GitHub
2. Create and push a version tag: `git tag v1.0.0 && git push origin v1.0.0`
3. Monitor GitHub Actions for successful build, sign, notarize, and release
4. Verify DMG download and installation on clean macOS system



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Provides a signed, notarized macOS DMG for easy installation on new tagged releases.
  * Automatically publishes versioned macOS releases.

* Security
  * Strengthens macOS app security with stricter sandbox and code-signing entitlements.

* Chores
  * Introduces an automated macOS release pipeline that builds, signs, notarizes, validates, and publishes the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->