### PR TITLE
feat(counter): Add Cmd+R shortcut to reset counter number

### DIFF
--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -1062,6 +1062,11 @@ class OverlayView: NSView, NSTextFieldDelegate {
         numberString.draw(in: textRect, withAttributes: attributes)
     }
 
+    /// Resets the counter number back to 1 without clearing existing counter annotations.
+    func resetCounter() {
+        nextCounterNumber = 1
+    }
+
     func clearAll() {
         cleanupActiveTextField()
 

--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -729,6 +729,15 @@ class OverlayWindow: NSPanel {
                     overlayView.undo()
                 }
             }
+        case 15:  // 'r' key
+            if cmdPressed
+                && !event.modifierFlags.contains(.shift)
+                && !event.modifierFlags.contains(.option)
+                && overlayView.currentTool == .counter
+            {
+                overlayView.resetCounter()
+                showToggleFeedback("Counter Reset", icon: "🔄")
+            }
         default:
             super.keyDown(with: event)
         }

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -177,6 +177,18 @@ final class OverlayViewTests: XCTestCase, Sendable {
         XCTAssertEqual(overlayView.currentTool, .counter)
     }
 
+    func testResetCounter() {
+        overlayView.nextCounterNumber = 5
+        overlayView.counterAnnotations = [
+            CounterAnnotation(number: 1, position: .zero, color: .blue)
+        ]
+
+        overlayView.resetCounter()
+
+        XCTAssertEqual(overlayView.nextCounterNumber, 1)
+        XCTAssertEqual(overlayView.counterAnnotations.count, 1, "Existing counters should remain")
+    }
+
     func testDeleteLastCounter() {
         // Add two counters
         let counter1 = CounterAnnotation(

--- a/AnnotateTests/OverlayWindowTests.swift
+++ b/AnnotateTests/OverlayWindowTests.swift
@@ -610,4 +610,59 @@ final class OverlayWindowTests: XCTestCase, Sendable {
 
         XCTAssertEqual(window.overlayView.currentLineWidth, 20.0)
     }
+
+    // MARK: - Counter Reset Tests
+
+    func testCmdRResetsCounterInCounterMode() {
+        window.overlayView.currentTool = .counter
+        window.overlayView.nextCounterNumber = 5
+
+        let cmdREvent = TestEvents.createKeyEvent(
+            type: .keyDown,
+            keyCode: 15,  // 'r' key
+            modifierFlags: .command,
+            characters: "r"
+        )
+
+        window.keyDown(with: cmdREvent!)
+
+        XCTAssertEqual(window.overlayView.nextCounterNumber, 1)
+    }
+
+    func testCmdRDoesNotResetCounterInOtherModes() {
+        window.overlayView.currentTool = .pen
+        window.overlayView.nextCounterNumber = 5
+
+        let cmdREvent = TestEvents.createKeyEvent(
+            type: .keyDown,
+            keyCode: 15,
+            modifierFlags: .command,
+            characters: "r"
+        )
+
+        window.keyDown(with: cmdREvent!)
+
+        XCTAssertEqual(window.overlayView.nextCounterNumber, 5, "Counter should not reset outside counter mode")
+    }
+
+    func testCmdRPreservesExistingCounterAnnotations() {
+        window.overlayView.currentTool = .counter
+        window.overlayView.nextCounterNumber = 3
+        window.overlayView.counterAnnotations = [
+            CounterAnnotation(number: 1, position: .zero, color: .red),
+            CounterAnnotation(number: 2, position: NSPoint(x: 100, y: 100), color: .red)
+        ]
+
+        let cmdREvent = TestEvents.createKeyEvent(
+            type: .keyDown,
+            keyCode: 15,
+            modifierFlags: .command,
+            characters: "r"
+        )
+
+        window.keyDown(with: cmdREvent!)
+
+        XCTAssertEqual(window.overlayView.nextCounterNumber, 1)
+        XCTAssertEqual(window.overlayView.counterAnnotations.count, 2, "Existing counters should remain")
+    }
 }

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Sometimes you need to emphasize a part of your screen or share ideas visually, a
 | Mouse Forward Button                                 | **Redo**             | Redo the last undone action (mouse button 4)                               |
 | <kbd>Command</kbd> + <kbd>Scroll</kbd>               | **Adjust Width**     | Quickly change line width                                                  |
 | <kbd>Shift</kbd> (while drawing)                     | **Constrain**        | Lines/Arrows: 45° angles; Pen/Highlighter: straight; Shapes: square/circle |
+| <kbd>Command</kbd> + <kbd>R</kbd>                    | **Reset Counter**    | Reset counter number to 1 (Counter tool only)                              |
 
 #### 📋 Copy/Paste (Select Mode Only)
 
@@ -218,6 +219,7 @@ Annotate provides flexible line width control:
 
 - Click anywhere to add sequential numbered circles (1, 2, 3...)
 - Numbers increment automatically with each click
+- Press <kbd>Command</kbd> + <kbd>R</kbd> to reset the counter back to 1 (existing counters remain)
 
 #### Select Tool
 


### PR DESCRIPTION
## Overview
Adds a keyboard shortcut (<kbd>Command</kbd> + <kbd>R</kbd>) to reset the counter tool's number back to 1 while preserving existing counter annotations on screen.

Resolves #40 

## Motivation
When using the counter tool for annotations, users may want to start a new sequence from 1 without clearing their existing numbered markers. Previously, there was no way to reset the counter number without clearing all annotations.

## Changes
- **OverlayView.swift**: Added `resetCounter()` method that resets `nextCounterNumber` to 1
- **OverlayWindow.swift**: Added keyboard handler for Cmd+R (keyCode 15) that triggers counter reset when in counter mode, with visual feedback
- **README.md**: Documented the new shortcut in the keyboard shortcuts table and counter tool section
- **OverlayViewTests.swift**: Added test for `resetCounter()` function
- **OverlayWindowTests.swift**: Added tests for:
  - Cmd+R resets counter in counter mode
  - Cmd+R does not reset counter in other tool modes
  - Cmd+R preserves existing counter annotations

## Breaking Changes
None

## Testing
- Unit tests verify `resetCounter()` sets `nextCounterNumber` to 1
- Unit tests verify keyboard shortcut only works in counter mode
- Unit tests verify existing counter annotations are preserved after reset
- All new tests pass

## Additional Notes
- The shortcut intentionally only works when the counter tool is active
- Visual feedback ("Counter Reset 🔄") is shown when the shortcut is triggered
- Modifier key checks ensure Cmd+Shift+R and Cmd+Option+R do not trigger the reset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Cmd+R keyboard shortcut to reset the counter back to 1 while preserving existing counter annotations.

* **Documentation**
  * Updated README with the new Counter reset shortcut information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->