### PR TITLE
feat: adjust text annotation font size with Cmd+Scroll

### DIFF
--- a/Annotate/Constants.swift
+++ b/Annotate/Constants.swift
@@ -23,6 +23,7 @@ extension UserDefaults {
     static let activeCursorStyleKey = "ActiveCursorStyle"
     static let activeCursorSizeKey = "ActiveCursorSize"
     static let persistTextModeKey = "PersistTextMode"
+    static let defaultTextFontSizeKey = "TextFontSize"
 }
 
 let colorPalette: [NSColor] = [
@@ -30,3 +31,18 @@ let colorPalette: [NSColor] = [
     .systemGreen, .cyan, .systemIndigo,
     .magenta, .white, .black,
 ]
+
+let defaultTextAnnotationFontSize: CGFloat = 18
+let textAnnotationFontSizeRange: ClosedRange<CGFloat> = 12...48
+
+extension UserDefaults {
+    var textToolFontSize: CGFloat {
+        get {
+            let stored = double(forKey: Self.defaultTextFontSizeKey)
+            return stored > 0 ? CGFloat(stored) : defaultTextAnnotationFontSize
+        }
+        set {
+            set(Double(newValue), forKey: Self.defaultTextFontSizeKey)
+        }
+    }
+}

--- a/Annotate/GeneralSettingsView.swift
+++ b/Annotate/GeneralSettingsView.swift
@@ -13,6 +13,8 @@ struct GeneralSettingsView: View {
     private var enableBoard = false
     @AppStorage(UserDefaults.persistTextModeKey)
     private var persistTextMode = false
+@AppStorage(UserDefaults.defaultTextFontSizeKey)
+    private var defaultTextSize: Double = Double(defaultTextAnnotationFontSize)
     @State private var boardOpacity: Double = BoardManager.shared.opacity
     @State private var clickEffectsEnabled: Bool = CursorHighlightManager.shared.clickEffectsEnabled
     @State private var cursorHighlightEnabled: Bool = CursorHighlightManager.shared.cursorHighlightEnabled
@@ -23,6 +25,8 @@ struct GeneralSettingsView: View {
     @State private var activeCursorSize: Double = Double(CursorHighlightManager.shared.activeCursorSize)
 
     var body: some View {
+        let minTextSize = Double(textAnnotationFontSizeRange.lowerBound)
+        let maxTextSize = Double(textAnnotationFontSizeRange.upperBound)
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 SettingsSection(
@@ -141,7 +145,38 @@ struct GeneralSettingsView: View {
                 Divider()
 
                 SettingsSection(
+                    icon: "textformat.size",
+                    title: "Text Tool",
+                    subtitle: "Adjust the default font size for text annotations"
+                ) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Default Text Size")
+                                .font(.system(size: 13, weight: .semibold))
+                            Spacer()
+                            Text("\(Int(defaultTextSize)) pt")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                        }
+                        HStack(spacing: 8) {
+                            Text("\(Int(minTextSize)) pt")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 50, alignment: .trailing)
+                            Slider(value: $defaultTextSize, in: minTextSize...maxTextSize, step: 1)
+                            Text("\(Int(maxTextSize)) pt")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 50, alignment: .leading)
+                        }
+                    }
+                }
+
+                Divider()
+
+                SettingsSection(
                     icon: "cursorarrow",
+
                     title: "Active Cursor",
                     subtitle: "Cursor appearance when overlay is active"
                 ) {

--- a/Annotate/GeneralSettingsView.swift
+++ b/Annotate/GeneralSettingsView.swift
@@ -13,7 +13,7 @@ struct GeneralSettingsView: View {
     private var enableBoard = false
     @AppStorage(UserDefaults.persistTextModeKey)
     private var persistTextMode = false
-@AppStorage(UserDefaults.defaultTextFontSizeKey)
+    @AppStorage(UserDefaults.defaultTextFontSizeKey)
     private var defaultTextSize: Double = Double(defaultTextAnnotationFontSize)
     @State private var boardOpacity: Double = BoardManager.shared.opacity
     @State private var clickEffectsEnabled: Bool = CursorHighlightManager.shared.clickEffectsEnabled
@@ -176,7 +176,6 @@ struct GeneralSettingsView: View {
 
                 SettingsSection(
                     icon: "cursorarrow",
-
                     title: "Active Cursor",
                     subtitle: "Cursor appearance when overlay is active"
                 ) {

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -1727,8 +1727,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
         resizeActiveTextFieldWidth(textField)
     }
 
-    func resizeActiveTextFieldWidth(_ textField: NSTextField? = nil) {
-        guard let textField = textField ?? activeTextField else { return }
+    func resizeActiveTextFieldWidth(_ textField: NSTextField) {
         let font = textField.font ?? NSFont.systemFont(ofSize: UserDefaults.standard.textToolFontSize)
         let size = textField.stringValue.size(withAttributes: [.font: font])
 

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -1551,7 +1551,8 @@ class OverlayView: NSView, NSTextFieldDelegate {
             self.finalizeTextAnnotation(textField)
         }
         activeTextField = textField
-        textField.font = NSFont.systemFont(ofSize: 18)
+        let fontSize = currentTextAnnotation?.fontSize ?? UserDefaults.standard.textToolFontSize
+        textField.font = NSFont.systemFont(ofSize: fontSize)
 
         let boardType = currentBoardType
         textField.backgroundColor = boardType == .blackboard
@@ -1708,7 +1709,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
             text: "",
             position: point,
             color: adaptColorForBoard(currentColor, boardType: currentBoardType),
-            fontSize: 18
+            fontSize: UserDefaults.standard.textToolFontSize
         )
         createTextField(at: point)
     }
@@ -1725,7 +1726,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
               textField === activeTextField else { return }
 
         let text = textField.stringValue
-        let font = textField.font ?? NSFont.systemFont(ofSize: 18)
+        let font = textField.font ?? NSFont.systemFont(ofSize: UserDefaults.standard.textToolFontSize)
         let size = text.size(withAttributes: [.font: font])
 
         let minWidth: CGFloat = 100

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -1724,16 +1724,17 @@ class OverlayView: NSView, NSTextFieldDelegate {
     func controlTextDidChange(_ notification: Notification) {
         guard let textField = notification.object as? NSTextField,
               textField === activeTextField else { return }
+        resizeActiveTextFieldWidth(textField)
+    }
 
-        let text = textField.stringValue
+    func resizeActiveTextFieldWidth(_ textField: NSTextField? = nil) {
+        guard let textField = textField ?? activeTextField else { return }
         let font = textField.font ?? NSFont.systemFont(ofSize: UserDefaults.standard.textToolFontSize)
-        let size = text.size(withAttributes: [.font: font])
+        let size = textField.stringValue.size(withAttributes: [.font: font])
 
         let minWidth: CGFloat = 100
         let maxWidth = (window?.frame.width ?? bounds.width) - textField.frame.origin.x - 20
-        let newWidth = min(max(minWidth, size.width + 32), maxWidth)
-
-        textField.frame.size.width = newWidth
+        textField.frame.size.width = min(max(minWidth, size.width + 32), maxWidth)
     }
 
     func isAnythingFading() -> Bool {

--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -972,6 +972,7 @@ class OverlayWindow: NSPanel {
         if let textField = overlayView.activeTextField {
             textField.font = NSFont.systemFont(ofSize: newSize)
             overlayView.currentTextAnnotation?.fontSize = newSize
+            overlayView.resizeActiveTextFieldWidth(textField)
             textField.needsDisplay = true
         }
 

--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -953,22 +953,18 @@ class OverlayWindow: NSPanel {
     }
     
     private func scrollWheelForFontSize(with event: NSEvent) {
-        let minFontSize: CGFloat = textAnnotationFontSizeRange.lowerBound
-        let maxFontSize: CGFloat = textAnnotationFontSizeRange.upperBound
-        let step: CGFloat = 1.0
-
         let scrollDelta = event.scrollingDeltaY
-        let increment: CGFloat = scrollDelta > 0 ? step : -step
+        guard scrollDelta != 0 else { return }
 
+        let step: CGFloat = 1.0
+        let increment: CGFloat = scrollDelta > 0 ? step : -step
         let currentSize = UserDefaults.standard.textToolFontSize
-        let newSize = max(minFontSize, min(maxFontSize, currentSize + increment))
+        let newSize = (currentSize + increment).clamped(to: textAnnotationFontSizeRange)
 
         guard newSize != currentSize else { return }
 
-        // Persist the new default font size
         UserDefaults.standard.textToolFontSize = newSize
 
-        // If a text field is currently active (in-progress text entry), update it live
         if let textField = overlayView.activeTextField {
             textField.font = NSFont.systemFont(ofSize: newSize)
             overlayView.currentTextAnnotation?.fontSize = newSize

--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -277,7 +277,7 @@ class OverlayWindow: NSPanel {
                         overlayView.currentTextAnnotation = existingAnnotation
 
                         let attributes: [NSAttributedString.Key: Any] = [
-                            .font: NSFont.systemFont(ofSize: 18)
+                            .font: NSFont.systemFont(ofSize: existingAnnotation.fontSize)
                         ]
                         let size = existingAnnotation.text.size(withAttributes: attributes)
 
@@ -296,7 +296,7 @@ class OverlayWindow: NSPanel {
                 text: "",
                 position: startPoint,
                 color: currentColor,
-                fontSize: 18
+                fontSize: UserDefaults.standard.textToolFontSize
             )
             overlayView.createTextField(at: startPoint)
         }
@@ -877,7 +877,11 @@ class OverlayWindow: NSPanel {
         let cmdPressed = event.modifierFlags.contains(.command)
         
         if cmdPressed {
-            scrollWheelForLineWidth(with: event)
+            if overlayView.currentTool == .text {
+                scrollWheelForFontSize(with: event)
+            } else {
+                scrollWheelForLineWidth(with: event)
+            }
         } else {
             // Default scroll behavior
             super.scrollWheel(with: event)
@@ -946,6 +950,37 @@ class OverlayWindow: NSPanel {
     private func showLineWidthFeedback(_ width: CGFloat) {
         let text = String(format: "Line Width: %.2f px", width)
         showFeedback(text, lineColor: overlayView.currentColor, lineWidth: width)
+    }
+    
+    private func scrollWheelForFontSize(with event: NSEvent) {
+        let minFontSize: CGFloat = textAnnotationFontSizeRange.lowerBound
+        let maxFontSize: CGFloat = textAnnotationFontSizeRange.upperBound
+        let step: CGFloat = 1.0
+
+        let scrollDelta = event.scrollingDeltaY
+        let increment: CGFloat = scrollDelta > 0 ? step : -step
+
+        let currentSize = UserDefaults.standard.textToolFontSize
+        let newSize = max(minFontSize, min(maxFontSize, currentSize + increment))
+
+        guard newSize != currentSize else { return }
+
+        // Persist the new default font size
+        UserDefaults.standard.textToolFontSize = newSize
+
+        // If a text field is currently active (in-progress text entry), update it live
+        if let textField = overlayView.activeTextField {
+            textField.font = NSFont.systemFont(ofSize: newSize)
+            overlayView.currentTextAnnotation?.fontSize = newSize
+            textField.needsDisplay = true
+        }
+
+        showFontSizeFeedback(newSize)
+    }
+
+    private func showFontSizeFeedback(_ size: CGFloat) {
+        let text = String(format: "Font Size: %.0f pt", size)
+        showFeedback(text)
     }
     
     func showToggleFeedback(_ text: String, icon: String) {

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -292,6 +292,36 @@ final class OverlayViewTests: XCTestCase, Sendable {
         overlayView.activeTextField = nil
     }
 
+    func testResizeActiveTextFieldWidthGrowsWithFontSize() {
+        let clickPoint = NSPoint(x: 100, y: 200)
+        overlayView.currentTool = .text
+        overlayView.currentTextAnnotation = TextAnnotation(
+            text: "", position: clickPoint, color: .black, fontSize: defaultTextAnnotationFontSize
+        )
+        overlayView.createTextField(at: clickPoint, withText: "Hello world", width: 100)
+
+        guard let textField = overlayView.activeTextField else {
+            XCTFail("Text field should be created")
+            return
+        }
+
+        textField.font = NSFont.systemFont(ofSize: textAnnotationFontSizeRange.lowerBound)
+        overlayView.resizeActiveTextFieldWidth()
+        let smallWidth = textField.frame.size.width
+
+        textField.font = NSFont.systemFont(ofSize: textAnnotationFontSizeRange.upperBound)
+        overlayView.resizeActiveTextFieldWidth()
+        let largeWidth = textField.frame.size.width
+
+        XCTAssertGreaterThan(
+            largeWidth, smallWidth,
+            "Text field width should grow when font size increases"
+        )
+
+        textField.removeFromSuperview()
+        overlayView.activeTextField = nil
+    }
+
     func testFinalizeTextAnnotationAccountsForPadding() {
         let clickPoint = NSPoint(x: 200, y: 300)
         overlayView.currentTool = .text

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -296,7 +296,7 @@ final class OverlayViewTests: XCTestCase, Sendable {
         let clickPoint = NSPoint(x: 200, y: 300)
         overlayView.currentTool = .text
         overlayView.currentTextAnnotation = TextAnnotation(
-            text: "", position: clickPoint, color: .red, fontSize: 18
+            text: "", position: clickPoint, color: .red, fontSize: defaultTextAnnotationFontSize
         )
         overlayView.createTextField(at: clickPoint, withText: "", width: 100)
 

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -306,11 +306,11 @@ final class OverlayViewTests: XCTestCase, Sendable {
         }
 
         textField.font = NSFont.systemFont(ofSize: textAnnotationFontSizeRange.lowerBound)
-        overlayView.resizeActiveTextFieldWidth()
+        overlayView.resizeActiveTextFieldWidth(textField)
         let smallWidth = textField.frame.size.width
 
         textField.font = NSFont.systemFont(ofSize: textAnnotationFontSizeRange.upperBound)
-        overlayView.resizeActiveTextFieldWidth()
+        overlayView.resizeActiveTextFieldWidth(textField)
         let largeWidth = textField.frame.size.width
 
         XCTAssertGreaterThan(

--- a/AnnotateTests/OverlayWindowTests.swift
+++ b/AnnotateTests/OverlayWindowTests.swift
@@ -343,7 +343,7 @@ final class OverlayWindowTests: XCTestCase, Sendable {
             text: "Test",
             position: NSPoint(x: 200, y: 200),
             color: .black,
-            fontSize: 18
+            fontSize: defaultTextAnnotationFontSize
         ))
 
         window.overlayView.currentTool = .select
@@ -387,7 +387,7 @@ final class OverlayWindowTests: XCTestCase, Sendable {
             text: "Test",
             position: NSPoint(x: 100, y: 100),
             color: .black,
-            fontSize: 18
+            fontSize: defaultTextAnnotationFontSize
         ))
 
         window.overlayView.activeTextField = NSTextField(frame: NSRect(x: 100, y: 100, width: 200, height: 30))

--- a/AnnotateTests/SelectionFeatureTests.swift
+++ b/AnnotateTests/SelectionFeatureTests.swift
@@ -141,7 +141,7 @@ final class SelectionFeatureTests: XCTestCase {
             text: "Hello",
             position: NSPoint(x: 100, y: 100),
             color: .black,
-            fontSize: 18
+            fontSize: defaultTextAnnotationFontSize
         )
         overlayView.textAnnotations.append(textAnnotation)
         
@@ -540,7 +540,7 @@ final class SelectionFeatureTests: XCTestCase {
             text: "Test",
             position: NSPoint(x: 700, y: 700),
             color: .black,
-            fontSize: 18
+            fontSize: defaultTextAnnotationFontSize
         ))
         
         // Switch to select mode
@@ -671,7 +671,7 @@ final class SelectionFeatureTests: XCTestCase {
             text: "Test",
             position: NSPoint(x: 700, y: 700),
             color: .black,
-            fontSize: 18
+            fontSize: defaultTextAnnotationFontSize
         ))
         
         overlayView.counterAnnotations.append(CounterAnnotation(
@@ -882,7 +882,7 @@ final class SelectionFeatureTests: XCTestCase {
             text: "Hello",
             position: NSPoint(x: 300, y: 300),
             color: .black,
-            fontSize: 18
+            fontSize: defaultTextAnnotationFontSize
         ))
         
         overlayView.currentTool = .select


### PR DESCRIPTION
## Summary

Adds adjustable font size for text annotations via **Cmd+Scroll** when the text tool is active.

## Behavior

- **Cmd+Scroll Up** → increase font size
- **Cmd+Scroll Down** → decrease font size
- Range: **12–48 pt** (defined by `textAnnotationFontSizeRange` in Constants.swift)
- Step: **1 pt** per scroll tick
- Persisted across sessions via `UserDefaults.textToolFontSize`
- Live update: if a text field is currently being typed into, the font size updates in real-time
- Visual feedback: shows `Font Size: N pt` toast (same UX pattern as line width)

## Implementation

When the text tool is active, `scrollWheel` dispatches `Cmd+Scroll` to the new `scrollWheelForFontSize` handler instead of `scrollWheelForLineWidth`. This is a natural extension of the existing scroll-to-adjust-property pattern.

```
Cmd+Scroll + any tool  → adjust line width  (existing)
Cmd+Scroll + text tool → adjust font size   (new)
```

Closes #45
Relates to #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live font-size feedback overlay while adjusting text size
  * "Text Tool" setting with slider to set default text size and allowable range
  * Scroll wheel now adjusts font size when text tool is active (other tools keep adjusting line width)

* **Bug Fixes**
  * Edited text annotations preserve their existing font size
  * New text annotations default to the saved font-size preference and respect min/max limits

* **Tests**
  * Tests updated to use centralized default text-size value
<!-- end of auto-generated comment: release notes by coderabbit.ai -->