### PR TITLE
fix(updater): Skip Sparkle startup in DEBUG builds

### DIFF
--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -78,8 +78,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
 
         setupBoardObservers()
 
+        #if DEBUG
+        let startUpdater = false
+        #else
+        let startUpdater = true
+        #endif
+
         updaterController = SPUStandardUpdaterController(
-            startingUpdater: true,
+            startingUpdater: startUpdater,
             updaterDelegate: nil,
             userDriverDelegate: nil
         )


### PR DESCRIPTION
## Summary
- Contributors cloning and building from Xcode were hitting "The update checker failed to start correctly" on launch (#48).
- Sparkle can't validate signatures on unsigned local builds, and the sandboxed XPC helpers (`com.epilande.Annotate-spks` / `-spki`) aren't wired up in development, so `SPUStandardUpdaterController` fails to start.
- Now we construct the controller with `startingUpdater: false` in DEBUG builds. Release builds are unchanged.

## User impact
- **Release builds:** no change. Auto-checks run every 24h; manual "Check for Updates..." works.
- **Debug builds:** no startup error. Scheduled checks are disabled and the manual menu item silently no-ops, which is fine for contributors running off `main`.

## Test plan
- [x] `xcodebuild -project Annotate.xcodeproj -scheme Annotate -configuration Debug build` succeeds
- [ ] Launch Debug build from Xcode → confirm no update-checker error dialog
- [ ] Build Release locally (or verify on next signed release) → confirm updater still starts and appcast is fetched

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted application update initialization behavior based on build configuration to optimize development and release environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->