### PR TITLE
docs: add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ Sometimes you need to emphasize a part of your screen or share ideas visually, a
 >
 > The app is code-signed and notarized for macOS Gatekeeper compatibility.
 
+### Homebrew
+
+Install via [Homebrew Cask](https://formulae.brew.sh/cask/annotate):
+
+```sh
+brew install --cask annotate
+```
+
 ### Build from Source
 
 1. **Clone the Repository:**


### PR DESCRIPTION
## Summary

Annotate is now available as a [Homebrew cask](https://formulae.brew.sh/cask/annotate) (merged in Homebrew/homebrew-cask#271078). This adds a **Homebrew** section to the README's Installation instructions.

```sh
brew install --cask annotate
```

## Details

- Placed between **Download Release** and **Build from Source**. The direct download stays first since Annotate's audience skews non-developer and the GitHub release is the canonical/freshest source the cask itself pulls from.
- No `brew upgrade` line: the cask is `auto_updates true`, so `brew upgrade` intentionally skips it and the app self-updates via Sparkle (already covered in the Auto-Updates section).

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Homebrew installation section to the README.
  * Included steps for installing the app with `brew install --cask annotate`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->