### PR TITLE
fix(text-tool): Grow text input to fit font size without clipping

### DIFF
--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -5,6 +5,11 @@ import Cocoa
 class AnnotationTextField: NSTextField {
     var onCommandReturn: (() -> Void)?
 
+    /// The unclamped left-edge x the field targets before any right-edge shifting. Set when
+    /// the field is created so that shrinking text after a left-shift can move it back toward
+    /// its natural position instead of staying stuck to the left.
+    var anchorX: CGFloat = 0
+
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         if event.modifierFlags.contains(.command) && event.keyCode == 36 {
             onCommandReturn?()
@@ -1534,8 +1539,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
             finalizeTextAnnotation(existingField)
         }
 
-        let minWidth: CGFloat = 100
-        let initialWidth = existingText.isEmpty ? minWidth : width
+        let initialWidth = existingText.isEmpty ? Self.textFieldMinWidth : width
         let isEditing = !existingText.isEmpty
 
         // Offset to align text cursor with click point:
@@ -1543,7 +1547,9 @@ class OverlayView: NSView, NSTextFieldDelegate {
         // Y: center the box on the click for new text (-height/2), -4 for editing (top padding only)
         let fontSize = currentTextAnnotation?.fontSize ?? UserDefaults.standard.textToolFontSize
         let font = NSFont.systemFont(ofSize: fontSize)
-        // Height grows with the font so large text (and the cursor) is not clipped top/bottom
+        // Size the empty new field to one line of the current font so large text and the cursor
+        // aren't clipped top/bottom. "Ay" is a full ascender+descender sample; reusing the same
+        // sizing helper as typing/editing keeps the height consistent across every path.
         let textFieldHeight = textFieldBoxSize(forText: "Ay", font: font).height
         let yOffset: CGFloat = isEditing ? -4 : -textFieldHeight / 2
         let textField = AnnotationTextField(
@@ -1554,6 +1560,8 @@ class OverlayView: NSView, NSTextFieldDelegate {
             self.finalizeTextAnnotation(textField)
         }
         activeTextField = textField
+        // Remember where the field started so resize can slide it back right as text shrinks.
+        textField.anchorX = textField.frame.origin.x
         textField.font = font
 
         let boardType = currentBoardType
@@ -1727,13 +1735,15 @@ class OverlayView: NSView, NSTextFieldDelegate {
         resizeActiveTextField(textField)
     }
 
+    /// Minimum width of the active text-editing field.
+    private static let textFieldMinWidth: CGFloat = 100
+
     /// The unclamped box size needed to fit `text` at `font`, including the field's
     /// padding (horizontal cursor slack and a 32pt height floor). Callers apply any
     /// screen-edge clamping themselves. Single source of truth for text-field sizing.
     private func textFieldBoxSize(forText text: String, font: NSFont) -> NSSize {
-        let minWidth: CGFloat = 100
         let size = text.size(withAttributes: [.font: font])
-        return NSSize(width: max(minWidth, size.width + 32), height: max(32, size.height + 8))
+        return NSSize(width: max(Self.textFieldMinWidth, size.width + 32), height: max(32, size.height + 8))
     }
 
     func resizeActiveTextField(_ textField: NSTextField) {
@@ -1745,9 +1755,11 @@ class OverlayView: NSView, NSTextFieldDelegate {
 
         // Fit the text, but never wider than the screen minus margins.
         let newWidth = min(box.width, availableWidth - margin * 2)
-        // If the box would overflow the right edge, slide it left to keep the text
-        // fully visible instead of clamping the width (which would clip the text).
-        let newX = min(textField.frame.origin.x, availableWidth - margin - newWidth)
+        // Anchor to where the field was created, sliding left only enough to keep the box on
+        // screen. Using the anchor (not the current origin) lets it move back right as the text
+        // shrinks, instead of staying stuck left after a previous overflow.
+        let anchorX = (textField as? AnnotationTextField)?.anchorX ?? textField.frame.origin.x
+        let newX = min(anchorX, availableWidth - margin - newWidth)
 
         textField.frame = NSRect(x: newX, y: textField.frame.origin.y, width: newWidth, height: box.height)
     }

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -1735,11 +1735,23 @@ class OverlayView: NSView, NSTextFieldDelegate {
         let size = textField.stringValue.size(withAttributes: [.font: font])
 
         let minWidth: CGFloat = 100
-        let maxWidth = (window?.frame.width ?? bounds.width) - textField.frame.origin.x - 20
-        let newWidth = min(max(minWidth, size.width + 32), maxWidth)
+        let margin: CGFloat = 20
+        let availableWidth = window?.frame.width ?? bounds.width
+
+        // Width that fits the text plus padding, never wider than the screen minus margins
+        let newWidth = min(max(minWidth, size.width + 32), availableWidth - margin * 2)
         // Grow height with the font so large text is not clipped top/bottom while editing
         let newHeight = max(32, size.height + 8)
-        textField.frame.size = NSSize(width: newWidth, height: newHeight)
+
+        // If the box would overflow the right edge, slide it left to keep the text
+        // fully visible instead of clamping the width (which would clip the text).
+        var newX = textField.frame.origin.x
+        let rightEdge = availableWidth - margin
+        if newX + newWidth > rightEdge {
+            newX = max(margin, rightEdge - newWidth)
+        }
+
+        textField.frame = NSRect(x: newX, y: textField.frame.origin.y, width: newWidth, height: newHeight)
     }
 
     func isAnythingFading() -> Bool {

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -1540,8 +1540,12 @@ class OverlayView: NSView, NSTextFieldDelegate {
 
         // Offset to align text cursor with click point:
         // X: -8 for left padding
-        // Y: -16 to center text vertically at click for new text, -4 for editing (top padding only)
-        let textFieldHeight: CGFloat = 32
+        // Y: center the box on the click for new text (-height/2), -4 for editing (top padding only)
+        let fontSize = currentTextAnnotation?.fontSize ?? UserDefaults.standard.textToolFontSize
+        let font = NSFont.systemFont(ofSize: fontSize)
+        // Height grows with the font so large text (and the cursor) is not clipped top/bottom
+        let lineHeight = ("Ay" as NSString).size(withAttributes: [.font: font]).height
+        let textFieldHeight = max(32, lineHeight + 8)
         let yOffset: CGFloat = isEditing ? -4 : -textFieldHeight / 2
         let textField = AnnotationTextField(
             frame: NSRect(x: point.x - 8, y: point.y + yOffset, width: initialWidth, height: textFieldHeight))
@@ -1551,8 +1555,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
             self.finalizeTextAnnotation(textField)
         }
         activeTextField = textField
-        let fontSize = currentTextAnnotation?.fontSize ?? UserDefaults.standard.textToolFontSize
-        textField.font = NSFont.systemFont(ofSize: fontSize)
+        textField.font = font
 
         let boardType = currentBoardType
         textField.backgroundColor = boardType == .blackboard
@@ -1724,16 +1727,19 @@ class OverlayView: NSView, NSTextFieldDelegate {
     func controlTextDidChange(_ notification: Notification) {
         guard let textField = notification.object as? NSTextField,
               textField === activeTextField else { return }
-        resizeActiveTextFieldWidth(textField)
+        resizeActiveTextField(textField)
     }
 
-    func resizeActiveTextFieldWidth(_ textField: NSTextField) {
+    func resizeActiveTextField(_ textField: NSTextField) {
         let font = textField.font ?? NSFont.systemFont(ofSize: UserDefaults.standard.textToolFontSize)
         let size = textField.stringValue.size(withAttributes: [.font: font])
 
         let minWidth: CGFloat = 100
         let maxWidth = (window?.frame.width ?? bounds.width) - textField.frame.origin.x - 20
-        textField.frame.size.width = min(max(minWidth, size.width + 32), maxWidth)
+        let newWidth = min(max(minWidth, size.width + 32), maxWidth)
+        // Grow height with the font so large text is not clipped top/bottom while editing
+        let newHeight = max(32, size.height + 8)
+        textField.frame.size = NSSize(width: newWidth, height: newHeight)
     }
 
     func isAnythingFading() -> Bool {

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -1544,8 +1544,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
         let fontSize = currentTextAnnotation?.fontSize ?? UserDefaults.standard.textToolFontSize
         let font = NSFont.systemFont(ofSize: fontSize)
         // Height grows with the font so large text (and the cursor) is not clipped top/bottom
-        let lineHeight = ("Ay" as NSString).size(withAttributes: [.font: font]).height
-        let textFieldHeight = max(32, lineHeight + 8)
+        let textFieldHeight = textFieldBoxSize(forText: "Ay", font: font).height
         let yOffset: CGFloat = isEditing ? -4 : -textFieldHeight / 2
         let textField = AnnotationTextField(
             frame: NSRect(x: point.x - 8, y: point.y + yOffset, width: initialWidth, height: textFieldHeight))
@@ -1591,9 +1590,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
         textField.layer?.masksToBounds = false
 
         if isEditing {
-            let size = existingText.size(withAttributes: [.font: textField.font!])
-            textField.frame.size.width = max(minWidth, size.width + 32)
-            textField.frame.size.height = max(32, size.height + 8)
+            textField.frame.size = textFieldBoxSize(forText: existingText, font: font)
         }
 
         self.addSubview(textField)
@@ -1730,28 +1727,29 @@ class OverlayView: NSView, NSTextFieldDelegate {
         resizeActiveTextField(textField)
     }
 
+    /// The unclamped box size needed to fit `text` at `font`, including the field's
+    /// padding (horizontal cursor slack and a 32pt height floor). Callers apply any
+    /// screen-edge clamping themselves. Single source of truth for text-field sizing.
+    private func textFieldBoxSize(forText text: String, font: NSFont) -> NSSize {
+        let minWidth: CGFloat = 100
+        let size = text.size(withAttributes: [.font: font])
+        return NSSize(width: max(minWidth, size.width + 32), height: max(32, size.height + 8))
+    }
+
     func resizeActiveTextField(_ textField: NSTextField) {
         let font = textField.font ?? NSFont.systemFont(ofSize: UserDefaults.standard.textToolFontSize)
-        let size = textField.stringValue.size(withAttributes: [.font: font])
+        let box = textFieldBoxSize(forText: textField.stringValue, font: font)
 
-        let minWidth: CGFloat = 100
         let margin: CGFloat = 20
         let availableWidth = window?.frame.width ?? bounds.width
 
-        // Width that fits the text plus padding, never wider than the screen minus margins
-        let newWidth = min(max(minWidth, size.width + 32), availableWidth - margin * 2)
-        // Grow height with the font so large text is not clipped top/bottom while editing
-        let newHeight = max(32, size.height + 8)
-
+        // Fit the text, but never wider than the screen minus margins.
+        let newWidth = min(box.width, availableWidth - margin * 2)
         // If the box would overflow the right edge, slide it left to keep the text
         // fully visible instead of clamping the width (which would clip the text).
-        var newX = textField.frame.origin.x
-        let rightEdge = availableWidth - margin
-        if newX + newWidth > rightEdge {
-            newX = max(margin, rightEdge - newWidth)
-        }
+        let newX = min(textField.frame.origin.x, availableWidth - margin - newWidth)
 
-        textField.frame = NSRect(x: newX, y: textField.frame.origin.y, width: newWidth, height: newHeight)
+        textField.frame = NSRect(x: newX, y: textField.frame.origin.y, width: newWidth, height: box.height)
     }
 
     func isAnythingFading() -> Bool {

--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -968,7 +968,7 @@ class OverlayWindow: NSPanel {
         if let textField = overlayView.activeTextField {
             textField.font = NSFont.systemFont(ofSize: newSize)
             overlayView.currentTextAnnotation?.fontSize = newSize
-            overlayView.resizeActiveTextFieldWidth(textField)
+            overlayView.resizeActiveTextField(textField)
             textField.needsDisplay = true
         }
 

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -258,6 +258,11 @@ final class OverlayViewTests: XCTestCase, Sendable {
 
     func testCreateTextFieldForNewTextCentersVertically() {
         let clickPoint = NSPoint(x: 200, y: 300)
+        // Pin the font so the box height (and the centering offset derived from it) is
+        // deterministic regardless of any persisted textToolFontSize.
+        overlayView.currentTextAnnotation = TextAnnotation(
+            text: "", position: clickPoint, color: .black, fontSize: defaultTextAnnotationFontSize
+        )
         overlayView.createTextField(at: clickPoint, withText: "", width: 100)
 
         guard let textField = overlayView.activeTextField else {
@@ -265,10 +270,35 @@ final class OverlayViewTests: XCTestCase, Sendable {
             return
         }
 
-        // For new text, Y offset should be -16 (half of 32px height) to center at click
-        // X offset is -8 for left padding
+        // At the default font the box is at its 32px floor, so Y offset is -16 (half the
+        // height) to center at the click. X offset is -8 for left padding.
         XCTAssertEqual(textField.frame.origin.x, clickPoint.x - 8, "X should offset by left padding")
         XCTAssertEqual(textField.frame.origin.y, clickPoint.y - 16, "Y should center text field at click point")
+
+        textField.removeFromSuperview()
+        overlayView.activeTextField = nil
+    }
+
+    func testCreateTextFieldForNewTextHeightGrowsWithFontSize() {
+        let clickPoint = NSPoint(x: 200, y: 300)
+        overlayView.currentTextAnnotation = TextAnnotation(
+            text: "", position: clickPoint, color: .black, fontSize: textAnnotationFontSizeRange.upperBound
+        )
+        overlayView.createTextField(at: clickPoint, withText: "", width: 100)
+
+        guard let textField = overlayView.activeTextField else {
+            XCTFail("Text field should be created")
+            return
+        }
+
+        XCTAssertGreaterThan(
+            textField.frame.height, 32,
+            "A new field created with a large font should be taller than the 32px floor so text is not clipped"
+        )
+        XCTAssertEqual(
+            textField.frame.midY, clickPoint.y, accuracy: 0.5,
+            "The taller box should stay vertically centered on the click point"
+        )
 
         textField.removeFromSuperview()
         overlayView.activeTextField = nil
@@ -305,6 +335,8 @@ final class OverlayViewTests: XCTestCase, Sendable {
             return
         }
 
+        let anchoredY = textField.frame.origin.y
+
         textField.font = NSFont.systemFont(ofSize: textAnnotationFontSizeRange.lowerBound)
         overlayView.resizeActiveTextField(textField)
         let smallSize = textField.frame.size
@@ -320,6 +352,10 @@ final class OverlayViewTests: XCTestCase, Sendable {
         XCTAssertGreaterThan(
             largeSize.height, smallSize.height,
             "Text field height should grow when font size increases so text is not clipped"
+        )
+        XCTAssertEqual(
+            textField.frame.origin.y, anchoredY,
+            "Growing the height should keep the bottom edge anchored so committed text does not jump"
         )
 
         textField.removeFromSuperview()

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -403,6 +403,44 @@ final class OverlayViewTests: XCTestCase, Sendable {
         overlayView.activeTextField = nil
     }
 
+    func testResizeActiveTextFieldReturnsToAnchorWhenTextShrinks() {
+        // Placed away from the right edge so a short string can return fully to the anchor.
+        let clickPoint = NSPoint(x: 600, y: 300)
+        overlayView.currentTool = .text
+        overlayView.currentTextAnnotation = TextAnnotation(
+            text: "", position: clickPoint, color: .black, fontSize: defaultTextAnnotationFontSize
+        )
+        overlayView.createTextField(at: clickPoint, withText: "", width: 100)
+
+        guard let textField = overlayView.activeTextField else {
+            XCTFail("Text field should be created")
+            return
+        }
+
+        let anchorX = textField.frame.origin.x
+        let font = NSFont.systemFont(ofSize: textAnnotationFontSizeRange.upperBound)
+        textField.font = font
+
+        // A long string overflows the right edge and slides the box left.
+        textField.stringValue = "A very long sentence that overflows the screen"
+        overlayView.resizeActiveTextField(textField)
+        XCTAssertLessThan(
+            textField.frame.origin.x, anchorX,
+            "Text field should slide left when the text overflows the right edge"
+        )
+
+        // Shrinking the text should let the box return to its creation anchor, not stay stuck left.
+        textField.stringValue = "Hi"
+        overlayView.resizeActiveTextField(textField)
+        XCTAssertEqual(
+            textField.frame.origin.x, anchorX, accuracy: 0.5,
+            "Text field should return to its creation anchor when the text fits there again"
+        )
+
+        textField.removeFromSuperview()
+        overlayView.activeTextField = nil
+    }
+
     func testFinalizeTextAnnotationAccountsForPadding() {
         let clickPoint = NSPoint(x: 200, y: 300)
         overlayView.currentTool = .text

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -292,7 +292,7 @@ final class OverlayViewTests: XCTestCase, Sendable {
         overlayView.activeTextField = nil
     }
 
-    func testResizeActiveTextFieldWidthGrowsWithFontSize() {
+    func testResizeActiveTextFieldGrowsWithFontSize() {
         let clickPoint = NSPoint(x: 100, y: 200)
         overlayView.currentTool = .text
         overlayView.currentTextAnnotation = TextAnnotation(
@@ -306,16 +306,20 @@ final class OverlayViewTests: XCTestCase, Sendable {
         }
 
         textField.font = NSFont.systemFont(ofSize: textAnnotationFontSizeRange.lowerBound)
-        overlayView.resizeActiveTextFieldWidth(textField)
-        let smallWidth = textField.frame.size.width
+        overlayView.resizeActiveTextField(textField)
+        let smallSize = textField.frame.size
 
         textField.font = NSFont.systemFont(ofSize: textAnnotationFontSizeRange.upperBound)
-        overlayView.resizeActiveTextFieldWidth(textField)
-        let largeWidth = textField.frame.size.width
+        overlayView.resizeActiveTextField(textField)
+        let largeSize = textField.frame.size
 
         XCTAssertGreaterThan(
-            largeWidth, smallWidth,
+            largeSize.width, smallSize.width,
             "Text field width should grow when font size increases"
+        )
+        XCTAssertGreaterThan(
+            largeSize.height, smallSize.height,
+            "Text field height should grow when font size increases so text is not clipped"
         )
 
         textField.removeFromSuperview()

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -326,6 +326,47 @@ final class OverlayViewTests: XCTestCase, Sendable {
         overlayView.activeTextField = nil
     }
 
+    func testResizeActiveTextFieldStaysOnScreenNearRightEdge() {
+        // The view is 800 wide with no window, so availableWidth falls back to bounds.width
+        let clickPoint = NSPoint(x: 790, y: 300)
+        overlayView.currentTool = .text
+        overlayView.currentTextAnnotation = TextAnnotation(
+            text: "", position: clickPoint, color: .black, fontSize: defaultTextAnnotationFontSize
+        )
+        overlayView.createTextField(at: clickPoint, withText: "", width: 100)
+
+        guard let textField = overlayView.activeTextField else {
+            XCTFail("Text field should be created")
+            return
+        }
+
+        let originalX = textField.frame.origin.x
+        let font = NSFont.systemFont(ofSize: textAnnotationFontSizeRange.upperBound)
+        textField.font = font
+        textField.stringValue = "Hello world test"
+        overlayView.resizeActiveTextField(textField)
+
+        let margin: CGFloat = 20
+        let rightEdge = overlayView.bounds.width - margin
+
+        XCTAssertLessThanOrEqual(
+            textField.frame.maxX, rightEdge,
+            "Text field should not overflow the right edge of the screen"
+        )
+        XCTAssertLessThan(
+            textField.frame.origin.x, originalX,
+            "Text field should slide left when it would overflow the right edge"
+        )
+        let textWidth = textField.stringValue.size(withAttributes: [.font: font]).width
+        XCTAssertGreaterThanOrEqual(
+            textField.frame.size.width, textWidth,
+            "Text field should stay wide enough to show the full text instead of clipping it"
+        )
+
+        textField.removeFromSuperview()
+        overlayView.activeTextField = nil
+    }
+
     func testFinalizeTextAnnotationAccountsForPadding() {
         let clickPoint = NSPoint(x: 200, y: 300)
         overlayView.currentTool = .text


### PR DESCRIPTION
## Summary

- Text-tool input boxes now grow in **height** with the font size, so large text (up to the 48pt max) is no longer clipped top/bottom while typing or after a Cmd+Scroll font change.
- The box also **slides left** instead of clipping when it would overflow the right screen edge.
- Box-sizing math is consolidated into a single helper.

Closes https://github.com/epilande/Annotate/issues/54

## Problem

The editing field's height was hardcoded to 32px while only its width grew per keystroke. At large font sizes a single line is ~40–57px tall, so glyphs were sliced top and bottom during editing (the reported "input doesn't grow and gets cut off"). Separately, a field placed near the right edge had its width clamped short of the text, clipping it.

## Changes

- **`OverlayView.createTextField`**: initial box height is derived from the font (`max(32, lineHeight + 8)`) so an empty large-font field and its cursor aren't clipped before the first keystroke.
- **`OverlayView.resizeActiveTextField`** (renamed from `resizeActiveTextFieldWidth`): grows width **and** height; slides the box left when it would overflow the right edge instead of clamping the width; keeps the bottom edge anchored so committed text doesn't jump.
- **`OverlayWindow.scrollWheelForFontSize`**: Cmd+Scroll font changes now regrow height too, not just width.
- **`textFieldBoxSize(forText:font:)`**: extracted as the single source of truth for the padding/min-size math that had been duplicated across three sites.

## Testing

- Unit tests (`OverlayViewTests`): height grows with font, box stays vertically centered on the click, bottom edge stays anchored (no commit jump), and slides left near the right edge. All 18 pass.
- Full suite: 337/338 pass. The one failure (`AppDelegateTests.testColorPicker`) is **pre-existing on `main`** and unrelated — it asserts a color popover is presented, which doesn't happen in a headless `xcodebuild` test run.
- Manually verified in a Debug build: large-font text renders fully, grows while typing, resizes live on Cmd+Scroll, and slides left near the right edge.

## Breaking Changes

None.

## Notes

- A separate, **pre-existing** "ghost text on edit" rendering bug (the original annotation drawn behind the edit field on double-click) was found while testing this. It has a different root cause (draw loop, not sizing) and is intentionally left out of this PR to be handled on its own branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Text annotations now auto-size more accurately as you type, including smoother width and height resizing.

* **Bug Fixes**
  * Live text resizing now preserves vertical centering and keeps text boxes fully on-screen near the right edge by shifting position as needed.
  * Changing the active text field’s font size updates its layout correctly.
  * Existing text annotations open with more consistent sizing and alignment, reducing clipping and layout jumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->