### PR TITLE
fix(text-tool): Stop drawing the edited annotation behind its edit field

### DIFF
--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -654,7 +654,10 @@ class OverlayView: NSView, NSTextFieldDelegate {
             if index == editingTextAnnotationIndex { continue }
             drawText(annotation)
         }
-        if let annotation = currentTextAnnotation {
+        // Only for new text (an empty placeholder). When editing an existing annotation,
+        // currentTextAnnotation IS that annotation and is shown by the edit field, so drawing
+        // it here would render a duplicate "ghost" behind the field.
+        if let annotation = currentTextAnnotation, editingTextAnnotationIndex == nil {
             drawText(annotation)
         }
 

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -68,6 +68,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
     var currentCircle: Circle?
 
     var textAnnotations: [TextAnnotation] = []
+    /// Annotation being created/edited; holds color and font size for finalize. Not rendered.
     var currentTextAnnotation: TextAnnotation?
     var activeTextField: NSTextField?
     var originalTextPosition: NSPoint?
@@ -648,16 +649,9 @@ class OverlayView: NSView, NSTextFieldDelegate {
             drawCircle(circle, alpha: 1.0)
         }
 
-        // Draw texts (text annotations don't fade - they persist regardless of fade mode)
+        // Text annotations persist regardless of fade mode.
         for (index, annotation) in textAnnotations.enumerated() {
-            // Skip drawing text that is currently being edited (prevents ghost text)
-            if index == editingTextAnnotationIndex { continue }
-            drawText(annotation)
-        }
-        // Only for new text (an empty placeholder). When editing an existing annotation,
-        // currentTextAnnotation IS that annotation and is shown by the edit field, so drawing
-        // it here would render a duplicate "ghost" behind the field.
-        if let annotation = currentTextAnnotation, editingTextAnnotationIndex == nil {
+            if index == editingTextAnnotationIndex { continue }  // skip the one being edited
             drawText(annotation)
         }
 

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -441,6 +441,47 @@ final class OverlayViewTests: XCTestCase, Sendable {
         overlayView.activeTextField = nil
     }
 
+    /// Renders the view offscreen and counts non-transparent pixels (a proxy for "something drew").
+    private func renderedPixelCount(of view: NSView) -> Int {
+        guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else { return -1 }
+        view.cacheDisplay(in: view.bounds, to: rep)
+        var count = 0
+        var y = 0
+        while y < rep.pixelsHigh {
+            var x = 0
+            while x < rep.pixelsWide {
+                if let color = rep.colorAt(x: x, y: y), color.alphaComponent > 0.1 { count += 1 }
+                x += 3
+            }
+            y += 3
+        }
+        return count
+    }
+
+    func testEditedAnnotationNotDrawnBehindEditField() {
+        let annotation = TextAnnotation(
+            text: "GHOST", position: NSPoint(x: 120, y: 300), color: .red, fontSize: 28
+        )
+        overlayView.textAnnotations = [annotation]
+
+        // Control: not editing — the committed annotation renders.
+        overlayView.editingTextAnnotationIndex = nil
+        overlayView.currentTextAnnotation = nil
+        XCTAssertGreaterThan(
+            renderedPixelCount(of: overlayView), 0,
+            "Sanity check: a committed text annotation should render"
+        )
+
+        // Editing this annotation (mirrors the double-click path, where currentTextAnnotation is
+        // set to the edited annotation): it must NOT be drawn as a ghost behind the edit field.
+        overlayView.editingTextAnnotationIndex = 0
+        overlayView.currentTextAnnotation = annotation
+        XCTAssertEqual(
+            renderedPixelCount(of: overlayView), 0,
+            "The annotation being edited must not be drawn behind the edit field"
+        )
+    }
+
     func testFinalizeTextAnnotationAccountsForPadding() {
         let clickPoint = NSPoint(x: 200, y: 300)
         overlayView.currentTool = .text

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -441,7 +441,7 @@ final class OverlayViewTests: XCTestCase, Sendable {
         overlayView.activeTextField = nil
     }
 
-    /// Renders the view offscreen and counts non-transparent pixels (a proxy for "something drew").
+    /// Offscreen-renders the view and counts its non-transparent pixels.
     private func renderedPixelCount(of view: NSView) -> Int {
         guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else { return -1 }
         view.cacheDisplay(in: view.bounds, to: rep)
@@ -464,7 +464,7 @@ final class OverlayViewTests: XCTestCase, Sendable {
         )
         overlayView.textAnnotations = [annotation]
 
-        // Control: not editing — the committed annotation renders.
+        // Not editing: the committed annotation renders.
         overlayView.editingTextAnnotationIndex = nil
         overlayView.currentTextAnnotation = nil
         XCTAssertGreaterThan(
@@ -472,8 +472,7 @@ final class OverlayViewTests: XCTestCase, Sendable {
             "Sanity check: a committed text annotation should render"
         )
 
-        // Editing this annotation (mirrors the double-click path, where currentTextAnnotation is
-        // set to the edited annotation): it must NOT be drawn as a ghost behind the edit field.
+        // Editing it (mirrors double-click): must not be drawn as a ghost behind the field.
         overlayView.editingTextAnnotationIndex = 0
         overlayView.currentTextAnnotation = annotation
         XCTAssertEqual(


### PR DESCRIPTION
## Summary

- Fixes the "ghost" text seen when editing a text annotation: on double-click, the original annotation was still painted behind the edit field.
- Removes the offending draw entirely (it was dead code) rather than special-casing it.

## Problem

Double-clicking a text annotation to edit it left a duplicate copy of the text rendered behind the edit field. `drawRect` correctly skips the annotation at `editingTextAnnotationIndex` in its loop, but then drew `currentTextAnnotation` unconditionally — and the double-click handler sets `currentTextAnnotation` to that same annotation (so `finalize` can save it), so it got painted a second time.

## Changes

- **`OverlayView.drawRect`**: delete the `currentTextAnnotation` draw. Tracing every use showed it never rendered a useful pixel — `currentTextAnnotation.text` is never updated live (the `NSTextField` owns the typed text), so it drew an empty string for new text and the ghost for editing.
- Documented `currentTextAnnotation` as a finalize-time carrier (color/font size + "editing in progress" sentinel), not a render source.

## Testing

- Added `testEditedAnnotationNotDrawnBehindEditField`: offscreen-renders the view and asserts the edited annotation isn't painted. Verified it's a real guard — fails without the fix (ghost pixels present), passes with it (0).
- All 20 `OverlayViewTests` pass; full suite green except the pre-existing, unrelated `testColorPicker` (fails on `main` too — it asserts a color popover is presented, which doesn't happen in a headless test run).
- Verified end-to-end in a Debug build and via before/after renders of the real `drawRect`.

## Breaking Changes

None. Behavior is identical minus the duplicate draw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text annotation rendering so the annotation being edited is no longer shown behind the edit field.
  * Clarified that text annotations remain visible in the overlay even when fade mode changes, while still excluding the active edit item from drawing.

* **Tests**
  * Added coverage for the edited-annotation rendering behavior to verify it appears normally when not editing and disappears during editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->