### PR TITLE
feat(counter): Add adjustable size for numbers

### DIFF
--- a/Annotate/Constants.swift
+++ b/Annotate/Constants.swift
@@ -24,6 +24,7 @@ extension UserDefaults {
     static let activeCursorSizeKey = "ActiveCursorSize"
     static let persistTextModeKey = "PersistTextMode"
     static let defaultTextFontSizeKey = "TextFontSize"
+    static let defaultCounterFontSizeKey = "CounterFontSize"
 }
 
 let colorPalette: [NSColor] = [
@@ -35,6 +36,12 @@ let colorPalette: [NSColor] = [
 let defaultTextAnnotationFontSize: CGFloat = 18
 let textAnnotationFontSizeRange: ClosedRange<CGFloat> = 12...48
 
+/// The number's font size in a freshly placed counter badge. The badge circle
+/// scales from this value (see `CounterAnnotation.radius`), preserving the
+/// original 15 pt radius / 2.5 pt stroke at this default.
+let defaultCounterFontSize: CGFloat = 14
+let counterFontSizeRange: ClosedRange<CGFloat> = 12...60
+
 extension UserDefaults {
     var textToolFontSize: CGFloat {
         get {
@@ -43,6 +50,16 @@ extension UserDefaults {
         }
         set {
             set(Double(newValue), forKey: Self.defaultTextFontSizeKey)
+        }
+    }
+
+    var counterToolFontSize: CGFloat {
+        get {
+            let stored = double(forKey: Self.defaultCounterFontSizeKey)
+            return stored > 0 ? CGFloat(stored) : defaultCounterFontSize
+        }
+        set {
+            set(Double(newValue), forKey: Self.defaultCounterFontSizeKey)
         }
     }
 }

--- a/Annotate/Constants.swift
+++ b/Annotate/Constants.swift
@@ -36,9 +36,8 @@ let colorPalette: [NSColor] = [
 let defaultTextAnnotationFontSize: CGFloat = 18
 let textAnnotationFontSizeRange: ClosedRange<CGFloat> = 12...48
 
-/// The number's font size in a freshly placed counter badge. The badge circle
-/// scales from this value (see `CounterAnnotation.radius`), preserving the
-/// original 15 pt radius / 2.5 pt stroke at this default.
+/// 14 pt reproduces counters' original 15 pt radius / 2.5 pt stroke; the badge
+/// scales from here (see `CounterAnnotation.radius`).
 let defaultCounterFontSize: CGFloat = 14
 let counterFontSizeRange: ClosedRange<CGFloat> = 12...60
 

--- a/Annotate/GeneralSettingsView.swift
+++ b/Annotate/GeneralSettingsView.swift
@@ -153,27 +153,11 @@ struct GeneralSettingsView: View {
                     title: "Text Tool",
                     subtitle: "Adjust the default font size for text annotations"
                 ) {
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            Text("Default Text Size")
-                                .font(.system(size: 13, weight: .semibold))
-                            Spacer()
-                            Text("\(Int(defaultTextSize)) pt")
-                                .font(.system(size: 11))
-                                .foregroundStyle(.secondary)
-                        }
-                        HStack(spacing: 8) {
-                            Text("\(Int(minTextSize)) pt")
-                                .font(.system(size: 11))
-                                .foregroundStyle(.secondary)
-                                .frame(width: 50, alignment: .trailing)
-                            Slider(value: $defaultTextSize, in: minTextSize...maxTextSize, step: 1)
-                            Text("\(Int(maxTextSize)) pt")
-                                .font(.system(size: 11))
-                                .foregroundStyle(.secondary)
-                                .frame(width: 50, alignment: .leading)
-                        }
-                    }
+                    DefaultSizeSliderRow(
+                        title: "Default Text Size",
+                        size: $defaultTextSize,
+                        range: minTextSize...maxTextSize
+                    )
                 }
 
                 Divider()
@@ -183,27 +167,11 @@ struct GeneralSettingsView: View {
                     title: "Counter Tool",
                     subtitle: "Adjust the default size for counter annotations"
                 ) {
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            Text("Default Counter Size")
-                                .font(.system(size: 13, weight: .semibold))
-                            Spacer()
-                            Text("\(Int(defaultCounterSize)) pt")
-                                .font(.system(size: 11))
-                                .foregroundStyle(.secondary)
-                        }
-                        HStack(spacing: 8) {
-                            Text("\(Int(minCounterSize)) pt")
-                                .font(.system(size: 11))
-                                .foregroundStyle(.secondary)
-                                .frame(width: 50, alignment: .trailing)
-                            Slider(value: $defaultCounterSize, in: minCounterSize...maxCounterSize, step: 1)
-                            Text("\(Int(maxCounterSize)) pt")
-                                .font(.system(size: 11))
-                                .foregroundStyle(.secondary)
-                                .frame(width: 50, alignment: .leading)
-                        }
-                    }
+                    DefaultSizeSliderRow(
+                        title: "Default Counter Size",
+                        size: $defaultCounterSize,
+                        range: minCounterSize...maxCounterSize
+                    )
                 }
 
                 Divider()
@@ -375,6 +343,36 @@ struct GeneralSettingsView: View {
         spotlightSize = Double(CursorHighlightManager.shared.spotlightSize)
         activeCursorStyle = CursorHighlightManager.shared.activeCursorStyle
         activeCursorSize = Double(CursorHighlightManager.shared.activeCursorSize)
+    }
+}
+
+private struct DefaultSizeSliderRow: View {
+    let title: String
+    @Binding var size: Double
+    let range: ClosedRange<Double>
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold))
+                Spacer()
+                Text("\(Int(size)) pt")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+            HStack(spacing: 8) {
+                Text("\(Int(range.lowerBound)) pt")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 50, alignment: .trailing)
+                Slider(value: $size, in: range, step: 1)
+                Text("\(Int(range.upperBound)) pt")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 50, alignment: .leading)
+            }
+        }
     }
 }
 

--- a/Annotate/GeneralSettingsView.swift
+++ b/Annotate/GeneralSettingsView.swift
@@ -15,6 +15,8 @@ struct GeneralSettingsView: View {
     private var persistTextMode = false
     @AppStorage(UserDefaults.defaultTextFontSizeKey)
     private var defaultTextSize: Double = Double(defaultTextAnnotationFontSize)
+    @AppStorage(UserDefaults.defaultCounterFontSizeKey)
+    private var defaultCounterSize: Double = Double(defaultCounterFontSize)
     @State private var boardOpacity: Double = BoardManager.shared.opacity
     @State private var clickEffectsEnabled: Bool = CursorHighlightManager.shared.clickEffectsEnabled
     @State private var cursorHighlightEnabled: Bool = CursorHighlightManager.shared.cursorHighlightEnabled
@@ -27,6 +29,8 @@ struct GeneralSettingsView: View {
     var body: some View {
         let minTextSize = Double(textAnnotationFontSizeRange.lowerBound)
         let maxTextSize = Double(textAnnotationFontSizeRange.upperBound)
+        let minCounterSize = Double(counterFontSizeRange.lowerBound)
+        let maxCounterSize = Double(counterFontSizeRange.upperBound)
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 SettingsSection(
@@ -165,6 +169,36 @@ struct GeneralSettingsView: View {
                                 .frame(width: 50, alignment: .trailing)
                             Slider(value: $defaultTextSize, in: minTextSize...maxTextSize, step: 1)
                             Text("\(Int(maxTextSize)) pt")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 50, alignment: .leading)
+                        }
+                    }
+                }
+
+                Divider()
+
+                SettingsSection(
+                    icon: "number.circle",
+                    title: "Counter Tool",
+                    subtitle: "Adjust the default size for counter annotations"
+                ) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Default Counter Size")
+                                .font(.system(size: 13, weight: .semibold))
+                            Spacer()
+                            Text("\(Int(defaultCounterSize)) pt")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                        }
+                        HStack(spacing: 8) {
+                            Text("\(Int(minCounterSize)) pt")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                                .frame(width: 50, alignment: .trailing)
+                            Slider(value: $defaultCounterSize, in: minCounterSize...maxCounterSize, step: 1)
+                            Text("\(Int(maxCounterSize)) pt")
                                 .font(.system(size: 11))
                                 .foregroundStyle(.secondary)
                                 .frame(width: 50, alignment: .leading)

--- a/Annotate/Models.swift
+++ b/Annotate/Models.swift
@@ -118,7 +118,16 @@ struct CounterAnnotation {
     var number: Int
     var position: NSPoint
     var color: NSColor
+    var fontSize: CGFloat = defaultCounterFontSize
     var creationTime: CFTimeInterval?
+
+    /// The badge circle radius, scaled from the number's font size so the
+    /// original 15 pt radius is preserved at the default 14 pt font.
+    var radius: CGFloat { fontSize * (15.0 / 14.0) }
+
+    /// The badge circle stroke width, scaled from the number's font size so the
+    /// original 2.5 pt stroke is preserved at the default 14 pt font.
+    var strokeWidth: CGFloat { fontSize * (2.5 / 14.0) }
 }
 
 enum ClipboardItem {
@@ -222,6 +231,7 @@ extension TextAnnotation: Equatable {
 extension CounterAnnotation: Equatable {
     public static func == (lhs: CounterAnnotation, rhs: CounterAnnotation) -> Bool {
         return lhs.number == rhs.number && lhs.position == rhs.position
-            && lhs.color.isEqual(rhs.color) && lhs.creationTime == rhs.creationTime
+            && lhs.color.isEqual(rhs.color) && lhs.fontSize == rhs.fontSize
+            && lhs.creationTime == rhs.creationTime
     }
 }

--- a/Annotate/Models.swift
+++ b/Annotate/Models.swift
@@ -128,6 +128,12 @@ struct CounterAnnotation {
     /// The badge circle stroke width, scaled from the number's font size so the
     /// original 2.5 pt stroke is preserved at the default 14 pt font.
     var strokeWidth: CGFloat { fontSize * (2.5 / 14.0) }
+
+    /// The badge circle's bounding rect, centered on the counter's position.
+    var badgeRect: NSRect {
+        NSRect(
+            x: position.x - radius, y: position.y - radius, width: radius * 2, height: radius * 2)
+    }
 }
 
 enum ClipboardItem {

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -811,7 +811,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
         case .counter(let index):
             guard index < counterAnnotations.count else { return .zero }
             let counter = counterAnnotations[index]
-            let radius: CGFloat = 15.0
+            let radius = counter.radius
             return NSRect(
                 x: counter.position.x - radius,
                 y: counter.position.y - radius,
@@ -1021,7 +1021,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
     private func drawCounter(_ counter: CounterAnnotation, alpha: CGFloat) {
         let adaptedColor = adaptColorForBoard(counter.color, boardType: currentBoardType)
 
-        let radius: CGFloat = 15.0
+        let radius = counter.radius
         let diameter = radius * 2
 
         let circleBounds = NSRect(
@@ -1037,13 +1037,13 @@ class OverlayView: NSView, NSTextFieldDelegate {
         circlePath.fill()
 
         adaptedColor.withAlphaComponent(alpha).setStroke()
-        circlePath.lineWidth = 2.5
+        circlePath.lineWidth = counter.strokeWidth
         circlePath.stroke()
 
         // Draw the number
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
-        let fontSize: CGFloat = 14.0
+        let fontSize = counter.fontSize
         let attributes: [NSAttributedString.Key: Any] = [
             .foregroundColor: adaptedColor.withAlphaComponent(alpha),
             .font: NSFont.systemFont(ofSize: fontSize, weight: .heavy),
@@ -1479,7 +1479,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
                 maxY = max(maxY, text.position.y + estimatedHeight)
 
             case .counter(let counter):
-                let radius: CGFloat = 15.0
+                let radius = counter.radius
                 minX = min(minX, counter.position.x - radius)
                 minY = min(minY, counter.position.y - radius)
                 maxX = max(maxX, counter.position.x + radius)
@@ -1988,13 +1988,21 @@ class OverlayView: NSView, NSTextFieldDelegate {
             
         case .counter(let index):
             guard index < counterAnnotations.count else { return false }
-            return rect.contains(counterAnnotations[index].position)
-            
+            let counter = counterAnnotations[index]
+            let radius = counter.radius
+            let counterRect = NSRect(
+                x: counter.position.x - radius,
+                y: counter.position.y - radius,
+                width: radius * 2,
+                height: radius * 2
+            )
+            return rect.intersects(counterRect)
+
         case .none:
             return false
         }
     }
-    
+
     /// Check if a line segment intersects with a rectangle
     private func lineSegmentIntersectsRect(start: NSPoint, end: NSPoint, rect: NSRect) -> Bool {
         // Check if either endpoint is inside the rectangle
@@ -2221,7 +2229,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
     }
     
     private func hitTestCounter(_ counter: CounterAnnotation, point: NSPoint) -> Bool {
-        let radius: CGFloat = 15.0
+        let radius = counter.radius
         let dx = point.x - counter.position.x
         let dy = point.y - counter.position.y
         let distance = sqrt(dx * dx + dy * dy)
@@ -2415,7 +2423,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
     }
 
     private func counterIntersectsPoint(_ counter: CounterAnnotation, point: NSPoint, radius: CGFloat) -> Bool {
-        let counterRadius: CGFloat = 15.0
+        let counterRadius = counter.radius
         let dx = point.x - counter.position.x
         let dy = point.y - counter.position.y
         let distance = sqrt(dx * dx + dy * dy)

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -810,15 +810,8 @@ class OverlayView: NSView, NSTextFieldDelegate {
             
         case .counter(let index):
             guard index < counterAnnotations.count else { return .zero }
-            let counter = counterAnnotations[index]
-            let radius = counter.radius
-            return NSRect(
-                x: counter.position.x - radius,
-                y: counter.position.y - radius,
-                width: radius * 2,
-                height: radius * 2
-            )
-            
+            return counterAnnotations[index].badgeRect
+
         case .none:
             return .zero
         }
@@ -1021,16 +1014,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
     private func drawCounter(_ counter: CounterAnnotation, alpha: CGFloat) {
         let adaptedColor = adaptColorForBoard(counter.color, boardType: currentBoardType)
 
-        let radius = counter.radius
-        let diameter = radius * 2
-
-        let circleBounds = NSRect(
-            x: counter.position.x - radius,
-            y: counter.position.y - radius,
-            width: diameter,
-            height: diameter
-        )
-        let circlePath = NSBezierPath(ovalIn: circleBounds)
+        let circlePath = NSBezierPath(ovalIn: counter.badgeRect)
 
         let backgroundColor = adaptedColor.contrastingColor()
         backgroundColor.withAlphaComponent(0.7 * alpha).setFill()
@@ -1043,10 +1027,9 @@ class OverlayView: NSView, NSTextFieldDelegate {
         // Draw the number
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
-        let fontSize = counter.fontSize
         let attributes: [NSAttributedString.Key: Any] = [
             .foregroundColor: adaptedColor.withAlphaComponent(alpha),
-            .font: NSFont.systemFont(ofSize: fontSize, weight: .heavy),
+            .font: NSFont.systemFont(ofSize: counter.fontSize, weight: .heavy),
             .paragraphStyle: paragraphStyle,
         ]
 
@@ -1479,11 +1462,11 @@ class OverlayView: NSView, NSTextFieldDelegate {
                 maxY = max(maxY, text.position.y + estimatedHeight)
 
             case .counter(let counter):
-                let radius = counter.radius
-                minX = min(minX, counter.position.x - radius)
-                minY = min(minY, counter.position.y - radius)
-                maxX = max(maxX, counter.position.x + radius)
-                maxY = max(maxY, counter.position.y + radius)
+                let box = counter.badgeRect
+                minX = min(minX, box.minX)
+                minY = min(minY, box.minY)
+                maxX = max(maxX, box.maxX)
+                maxY = max(maxY, box.maxY)
             }
         }
 
@@ -1988,15 +1971,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
             
         case .counter(let index):
             guard index < counterAnnotations.count else { return false }
-            let counter = counterAnnotations[index]
-            let radius = counter.radius
-            let counterRect = NSRect(
-                x: counter.position.x - radius,
-                y: counter.position.y - radius,
-                width: radius * 2,
-                height: radius * 2
-            )
-            return rect.intersects(counterRect)
+            return rect.intersects(counterAnnotations[index].badgeRect)
 
         case .none:
             return false

--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -242,6 +242,7 @@ class OverlayWindow: NSPanel {
                 number: overlayView.nextCounterNumber,
                 position: startPoint,
                 color: currentColor,
+                fontSize: UserDefaults.standard.counterToolFontSize,
                 creationTime: CACurrentMediaTime()
             )
 
@@ -879,6 +880,8 @@ class OverlayWindow: NSPanel {
         if cmdPressed {
             if overlayView.currentTool == .text {
                 scrollWheelForFontSize(with: event)
+            } else if overlayView.currentTool == .counter {
+                scrollWheelForCounterSize(with: event)
             } else {
                 scrollWheelForLineWidth(with: event)
             }
@@ -977,6 +980,27 @@ class OverlayWindow: NSPanel {
 
     private func showFontSizeFeedback(_ size: CGFloat) {
         let text = String(format: "Font Size: %.0f pt", size)
+        showFeedback(text)
+    }
+
+    private func scrollWheelForCounterSize(with event: NSEvent) {
+        let scrollDelta = event.scrollingDeltaY
+        guard scrollDelta != 0 else { return }
+
+        let step: CGFloat = 1.0
+        let increment: CGFloat = scrollDelta > 0 ? step : -step
+        let currentSize = UserDefaults.standard.counterToolFontSize
+        let newSize = (currentSize + increment).clamped(to: counterFontSizeRange)
+
+        guard newSize != currentSize else { return }
+
+        UserDefaults.standard.counterToolFontSize = newSize
+
+        showCounterSizeFeedback(newSize)
+    }
+
+    private func showCounterSizeFeedback(_ size: CGFloat) {
+        let text = String(format: "Counter Size: %.0f pt", size)
         showFeedback(text)
     }
     

--- a/AnnotateTests/EraserToolTests.swift
+++ b/AnnotateTests/EraserToolTests.swift
@@ -163,7 +163,6 @@ final class EraserToolTests: XCTestCase, Sendable {
     }
 
     func testEraseLargeCounterBeyondDefaultRadius() {
-        // A 60 pt counter's badge (radius ~64) reaches far past the original 15 pt.
         overlayView.counterAnnotations.append(CounterAnnotation(
             number: 1,
             position: NSPoint(x: 150, y: 150),

--- a/AnnotateTests/EraserToolTests.swift
+++ b/AnnotateTests/EraserToolTests.swift
@@ -162,6 +162,34 @@ final class EraserToolTests: XCTestCase, Sendable {
         XCTAssertEqual(overlayView.counterAnnotations.count, 0)
     }
 
+    func testEraseLargeCounterBeyondDefaultRadius() {
+        // A 60 pt counter's badge (radius ~64) reaches far past the original 15 pt.
+        overlayView.counterAnnotations.append(CounterAnnotation(
+            number: 1,
+            position: NSPoint(x: 150, y: 150),
+            color: .systemOrange,
+            fontSize: 60
+        ))
+
+        // 40 pt away: outside a default badge + eraser reach, but inside the large one.
+        overlayView.eraseAtPoint(NSPoint(x: 190, y: 150))
+
+        XCTAssertEqual(overlayView.counterAnnotations.count, 0)
+    }
+
+    func testEraseDefaultCounterIgnoresPointBeyondBadge() {
+        overlayView.counterAnnotations.append(CounterAnnotation(
+            number: 1,
+            position: NSPoint(x: 150, y: 150),
+            color: .systemOrange
+        ))
+
+        // The same 40 pt point must not erase a default-size badge.
+        overlayView.eraseAtPoint(NSPoint(x: 190, y: 150))
+
+        XCTAssertEqual(overlayView.counterAnnotations.count, 1)
+    }
+
     // MARK: - Eraser Radius Tests
 
     func testEraserDoesNotEraseOutsideRadius() {

--- a/AnnotateTests/ModelTests.swift
+++ b/AnnotateTests/ModelTests.swift
@@ -135,6 +135,40 @@ final class ModelTests: XCTestCase {
         XCTAssertNotEqual(counter, differentCounter)
     }
 
+    func testCounterAnnotationDefaultSizePreservesOriginalGeometry() {
+        // A counter created without an explicit size must render exactly as it did
+        // before the adjustable-size feature: 15 pt radius, 2.5 pt stroke.
+        let counter = CounterAnnotation(number: 1, position: .zero, color: .red)
+        XCTAssertEqual(counter.fontSize, defaultCounterFontSize)
+        XCTAssertEqual(counter.radius, 15, accuracy: 0.0001)
+        XCTAssertEqual(counter.strokeWidth, 2.5, accuracy: 0.0001)
+    }
+
+    func testCounterAnnotationRadiusAndStrokeScaleWithFontSize() {
+        let base = CounterAnnotation(number: 1, position: .zero, color: .red)
+        let doubled = CounterAnnotation(
+            number: 1, position: .zero, color: .red, fontSize: defaultCounterFontSize * 2)
+        XCTAssertEqual(doubled.radius, base.radius * 2, accuracy: 0.0001)
+        XCTAssertEqual(doubled.strokeWidth, base.strokeWidth * 2, accuracy: 0.0001)
+    }
+
+    func testCounterAnnotationEqualityIncludesFontSize() {
+        let base = CounterAnnotation(number: 1, position: .zero, color: .red, fontSize: 20)
+        let sameSize = CounterAnnotation(number: 1, position: .zero, color: .red, fontSize: 20)
+        let biggerSize = CounterAnnotation(number: 1, position: .zero, color: .red, fontSize: 40)
+        XCTAssertEqual(base, sameSize)
+        XCTAssertNotEqual(base, biggerSize)
+    }
+
+    func testCounterToolFontSizeDefaultsAndPersists() {
+        let defaults = TestUserDefaults.create()
+        // Unset falls back to the default size.
+        XCTAssertEqual(defaults.counterToolFontSize, defaultCounterFontSize)
+        // A stored value is read back.
+        defaults.counterToolFontSize = 42
+        XCTAssertEqual(defaults.counterToolFontSize, 42)
+    }
+
     func testToolType() {
         let tools: [ToolType] = [.pen, .arrow, .highlighter, .rectangle, .circle, .text]
         XCTAssertEqual(tools.count, 6)  // Ensure we have all tool types

--- a/AnnotateTests/ModelTests.swift
+++ b/AnnotateTests/ModelTests.swift
@@ -136,8 +136,6 @@ final class ModelTests: XCTestCase {
     }
 
     func testCounterAnnotationDefaultSizePreservesOriginalGeometry() {
-        // A counter created without an explicit size must render exactly as it did
-        // before the adjustable-size feature: 15 pt radius, 2.5 pt stroke.
         let counter = CounterAnnotation(number: 1, position: .zero, color: .red)
         XCTAssertEqual(counter.fontSize, defaultCounterFontSize)
         XCTAssertEqual(counter.radius, 15, accuracy: 0.0001)
@@ -162,9 +160,7 @@ final class ModelTests: XCTestCase {
 
     func testCounterToolFontSizeDefaultsAndPersists() {
         let defaults = TestUserDefaults.create()
-        // Unset falls back to the default size.
         XCTAssertEqual(defaults.counterToolFontSize, defaultCounterFontSize)
-        // A stored value is read back.
         defaults.counterToolFontSize = 42
         XCTAssertEqual(defaults.counterToolFontSize, 42)
     }

--- a/AnnotateTests/OverlayWindowTests.swift
+++ b/AnnotateTests/OverlayWindowTests.swift
@@ -228,6 +228,56 @@ final class OverlayWindowTests: XCTestCase, Sendable {
         XCTAssertGreaterThanOrEqual(initialWidth, 0.5, "Initial width should be within valid range")
         XCTAssertLessThanOrEqual(initialWidth, 20.0, "Initial width should be within valid range")
     }
+
+    func testScrollWheelAdjustsCounterSizeWhenCounterToolActive() {
+        window.overlayView.currentTool = .counter
+        let original = UserDefaults.standard.counterToolFontSize
+        defer { UserDefaults.standard.counterToolFontSize = original }
+
+        UserDefaults.standard.counterToolFontSize = 20
+
+        if let scrollUp = TestEvents.createScrollEvent(deltaY: 1.0, modifierFlags: .command) {
+            window.scrollWheel(with: scrollUp)
+        }
+        XCTAssertEqual(
+            UserDefaults.standard.counterToolFontSize, 21,
+            "Cmd+Scroll up should grow the counter size")
+
+        if let scrollDown = TestEvents.createScrollEvent(deltaY: -1.0, modifierFlags: .command) {
+            window.scrollWheel(with: scrollDown)
+        }
+        XCTAssertEqual(
+            UserDefaults.standard.counterToolFontSize, 20,
+            "Cmd+Scroll down should shrink the counter size")
+    }
+
+    func testScrollWheelClampsCounterSizeToUpperBound() {
+        window.overlayView.currentTool = .counter
+        let original = UserDefaults.standard.counterToolFontSize
+        defer { UserDefaults.standard.counterToolFontSize = original }
+
+        UserDefaults.standard.counterToolFontSize = counterFontSizeRange.upperBound
+        if let scrollUp = TestEvents.createScrollEvent(deltaY: 1.0, modifierFlags: .command) {
+            window.scrollWheel(with: scrollUp)
+        }
+        XCTAssertEqual(
+            UserDefaults.standard.counterToolFontSize, counterFontSizeRange.upperBound,
+            "Counter size must not exceed its range")
+    }
+
+    func testScrollWheelForNonCounterToolLeavesCounterSizeUntouched() {
+        window.overlayView.currentTool = .pen
+        let original = UserDefaults.standard.counterToolFontSize
+        defer { UserDefaults.standard.counterToolFontSize = original }
+
+        UserDefaults.standard.counterToolFontSize = 25
+        if let scrollUp = TestEvents.createScrollEvent(deltaY: 1.0, modifierFlags: .command) {
+            window.scrollWheel(with: scrollUp)
+        }
+        XCTAssertEqual(
+            UserDefaults.standard.counterToolFontSize, 25,
+            "A non-counter tool must route Cmd+Scroll elsewhere and leave counter size alone")
+    }
     
     func testToolFeedbackMethodExists() {
         // Test that showToolFeedback method can be called without errors

--- a/AnnotateTests/SelectionFeatureTests.swift
+++ b/AnnotateTests/SelectionFeatureTests.swift
@@ -252,7 +252,6 @@ final class SelectionFeatureTests: XCTestCase {
     }
 
     func testRectangleSelectionSelectsLargeCounterOverlappingBadgeNotCenter() {
-        // A large counter's badge scales with its font size (radius = fontSize * 15/14).
         // At 60 pt the badge spans roughly [435.7, 564.3] around center (500, 500).
         overlayView.counterAnnotations.append(CounterAnnotation(
             number: 1,
@@ -279,7 +278,6 @@ final class SelectionFeatureTests: XCTestCase {
             creationTime: nil
         ))
 
-        // Marquee well clear of the ~64 pt radius badge should not select the counter.
         let rect = NSRect(x: 100, y: 100, width: 50, height: 50)
         let foundObjects = overlayView.findObjectsInRect(rect)
 

--- a/AnnotateTests/SelectionFeatureTests.swift
+++ b/AnnotateTests/SelectionFeatureTests.swift
@@ -247,10 +247,45 @@ final class SelectionFeatureTests: XCTestCase {
         // Rectangle that doesn't cover anything
         let rect = NSRect(x: 300, y: 300, width: 50, height: 50)
         let foundObjects = overlayView.findObjectsInRect(rect)
-        
+
         XCTAssertTrue(foundObjects.isEmpty)
     }
-    
+
+    func testRectangleSelectionSelectsLargeCounterOverlappingBadgeNotCenter() {
+        // A large counter's badge scales with its font size (radius = fontSize * 15/14).
+        // At 60 pt the badge spans roughly [435.7, 564.3] around center (500, 500).
+        overlayView.counterAnnotations.append(CounterAnnotation(
+            number: 1,
+            position: NSPoint(x: 500, y: 500),
+            color: .red,
+            fontSize: 60,
+            creationTime: nil
+        ))
+
+        // Marquee overlaps the badge but stops short of the center point (maxX = 495 < 500).
+        // Center-point-only selection would miss it; area-based selection includes it.
+        let rect = NSRect(x: 440, y: 440, width: 55, height: 120)
+        let foundObjects = overlayView.findObjectsInRect(rect)
+
+        XCTAssertTrue(foundObjects.contains(.counter(index: 0)))
+    }
+
+    func testRectangleSelectionMissesCounterOutsideBadge() {
+        overlayView.counterAnnotations.append(CounterAnnotation(
+            number: 1,
+            position: NSPoint(x: 500, y: 500),
+            color: .red,
+            fontSize: 60,
+            creationTime: nil
+        ))
+
+        // Marquee well clear of the ~64 pt radius badge should not select the counter.
+        let rect = NSRect(x: 100, y: 100, width: 50, height: 50)
+        let foundObjects = overlayView.findObjectsInRect(rect)
+
+        XCTAssertFalse(foundObjects.contains(.counter(index: 0)))
+    }
+
     // MARK: - Bounding Box Tests
     
     func testGetObjectBoundsLine() {


### PR DESCRIPTION
## Summary

- Counter (number) badges are now resizable from **12–60 pt** (default 14 pt), so numbers can stand out on small screens for tutorials and courses.
- The circle, stroke, and number scale together, keeping badges proportioned. The original look is preserved at the default size.
- Mirrors the app's existing adjustable text-font-size UX for consistency.

Closes #55

## Screenshots

<img width="674" height="423" alt="image" src="https://github.com/user-attachments/assets/272de63f-f482-4724-a3c7-19492a095f1b" />


## Changes

**Model & constants**
- `CounterAnnotation` gains a `fontSize` field (default `defaultCounterFontSize` = 14) plus derived `radius` (`fontSize · 15/14`) and `strokeWidth` (`fontSize · 2.5/14`) so geometry scales from one value while preserving the original 15 pt radius / 2.5 pt stroke at the default. Added `fontSize` to `Equatable`.
- New `counterFontSizeRange` (12…60) and a `counterToolFontSize` `UserDefaults` accessor.

**Interaction**
- **Cmd + Scroll** adjusts counter size while the Counter tool is active, with a "Counter Size: N pt" readout (matches the text tool's Cmd+Scroll).
- New **Counter Tool** section in General settings with a default-size slider.
- New counters are created at the stored default size; size is carried through copy/paste and undo/redo.

**Geometry consistency**
- All counter geometry now derives from the annotation's size: drawing, both bounding-box calculations, click hit-testing, and eraser intersection.
- Fixed marquee (rubber-band) selection, which previously tested only a counter's center point, to use area intersection like every other annotation, so large badges are selectable when a drag overlaps the badge but not its center.

## Testing

- `xcodebuild ... build` succeeds.
- Full test suite passes (the sole failure, `AppDelegateTests.testColorPicker`, is pre-existing and environment-dependent, unrelated to this change).
- Added 2 regression tests for marquee selection of large counters.
- Manually verified in a Debug build: Cmd+Scroll sizing, the settings slider, placing/selecting/erasing/undoing large counters across sizes.

## Breaking Changes

None. Existing counters render identically at the default size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a customizable default size for counter annotations, including a new “Counter Size” slider in Settings and “Counter Size: … pt” feedback.
  * Counter annotations now scale their badge visuals (ring size/thickness and number size) based on the selected size.

* **Bug Fixes**
  * Improved counter selection and rectangle-selection behavior to match the badge area, not just the counter center.
  * Updated counter erasing and hit-testing to use the resized badge geometry.

* **Improvements**
  * Persisted the chosen counter size for newly created counters and refined Cmd+Scroll resizing to apply only to the counter tool (with clamped limits).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->