### PR TITLE
feat(tools): Add configurable default tool setting

### DIFF
--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -72,6 +72,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
 
         let persistedTool = userDefaults.lastUsedTool
         overlayWindows.values.forEach { $0.overlayView.currentTool = persistedTool }
+        updateCurrentToolMenuItem(to: persistedTool.displayName)
 
         let enableBoard = userDefaults.bool(forKey: UserDefaults.enableBoardKey)
         overlayWindows.values.forEach {

--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -559,6 +559,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
             window.invalidateCursorRects(for: window.overlayView)
             window.overlayView.updateCursor()
         }
+        updateCurrentToolMenuItem(to: tool.displayName)
         showOverlay()
     }
 
@@ -567,57 +568,46 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
     func applyConfiguredDefaultTool() {
         guard case .tool(let tool) = userDefaults.defaultToolOption else { return }
         switchTool(to: tool)
-        updateCurrentToolMenuItem(to: tool.displayName)
     }
 
     @objc func enableArrowMode(_ sender: NSMenuItem) {
         switchTool(to: .arrow)
-        updateCurrentToolMenuItem(to: "Arrow")
     }
 
     @objc func enableLineMode(_ sender: NSMenuItem) {
         switchTool(to: .line)
-        updateCurrentToolMenuItem(to: "Line")
     }
 
     @objc func enablePenMode(_ sender: NSMenuItem) {
         switchTool(to: .pen)
-        updateCurrentToolMenuItem(to: "Pen")
     }
 
     @objc func enableHighlighterMode(_ sender: NSMenuItem) {
         switchTool(to: .highlighter)
-        updateCurrentToolMenuItem(to: "Highlighter")
     }
 
     @objc func enableRectangleMode(_ sender: NSMenuItem) {
         switchTool(to: .rectangle)
-        updateCurrentToolMenuItem(to: "Rectangle")
     }
 
     @objc func enableCircleMode(_ sender: NSMenuItem) {
         switchTool(to: .circle)
-        updateCurrentToolMenuItem(to: "Circle")
     }
 
     @objc func enableCounterMode(_ sender: NSMenuItem) {
         switchTool(to: .counter)
-        updateCurrentToolMenuItem(to: "Counter")
     }
 
     @objc func enableTextMode(_ sender: NSMenuItem) {
         switchTool(to: .text)
-        updateCurrentToolMenuItem(to: "Text")
     }
-    
+
     @objc func enableSelectMode(_ sender: NSMenuItem) {
         switchTool(to: .select)
-        updateCurrentToolMenuItem(to: "Select")
     }
 
     @objc func enableEraserMode(_ sender: NSMenuItem) {
         switchTool(to: .eraser)
-        updateCurrentToolMenuItem(to: "Eraser")
     }
 
     @objc func toggleBoardVisibility(_ sender: Any?) {

--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -564,9 +564,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
     }
 
     /// Applies the configured default tool when the overlay activates. Does nothing when the
-    /// setting is "Last used", leaving whatever tool is already current in place.
+    /// setting is "Last used", leaving whatever tool is already current in place, or when
+    /// every window is already on the configured tool (avoids showing tool feedback on
+    /// every activation).
     func applyConfiguredDefaultTool() {
         guard case .tool(let tool) = userDefaults.defaultToolOption else { return }
+        guard overlayWindows.values.contains(where: { $0.overlayView.currentTool != tool }) else { return }
         switchTool(to: tool)
     }
 

--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -70,6 +70,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
         let persistedLineWidth = userDefaults.object(forKey: UserDefaults.lineWidthKey) as? Double ?? 3.0
         overlayWindows.values.forEach { $0.overlayView.currentLineWidth = CGFloat(persistedLineWidth) }
 
+        let persistedTool = userDefaults.lastUsedTool
+        overlayWindows.values.forEach { $0.overlayView.currentTool = persistedTool }
+
         let enableBoard = userDefaults.bool(forKey: UserDefaults.enableBoardKey)
         overlayWindows.values.forEach {
             $0.boardView.isHidden = !enableBoard
@@ -364,6 +367,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
 
                 let savedLineWidth = userDefaults.object(forKey: UserDefaults.lineWidthKey) as? Double ?? 3.0
                 overlayWindow.overlayView.currentLineWidth = CGFloat(savedLineWidth)
+                overlayWindow.overlayView.currentTool = userDefaults.lastUsedTool
 
                 overlayWindows[screen] = overlayWindow
             }
@@ -471,6 +475,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
             overlayWindow.makeKeyAndOrderFront(nil)
             CursorHighlightManager.shared.annotationColor = currentColor
             CursorHighlightManager.shared.overlayVisibilityChanged()
+            applyConfiguredDefaultTool()
         }
     }
 
@@ -538,6 +543,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
             toggleAlwaysOnMode()
         }
 
+        userDefaults.lastUsedTool = tool
+
         overlayWindows.values.forEach { window in
             if window.overlayView.currentTool == .select && tool != .select {
                 window.overlayView.selectedObjects.removeAll()
@@ -553,6 +560,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
             window.overlayView.updateCursor()
         }
         showOverlay()
+    }
+
+    /// Applies the configured default tool when the overlay activates. Does nothing when the
+    /// setting is "Last used", leaving whatever tool is already current in place.
+    func applyConfiguredDefaultTool() {
+        guard case .tool(let tool) = userDefaults.defaultToolOption else { return }
+        switchTool(to: tool)
+        updateCurrentToolMenuItem(to: tool.displayName)
     }
 
     @objc func enableArrowMode(_ sender: NSMenuItem) {

--- a/Annotate/Constants.swift
+++ b/Annotate/Constants.swift
@@ -25,6 +25,8 @@ extension UserDefaults {
     static let persistTextModeKey = "PersistTextMode"
     static let defaultTextFontSizeKey = "TextFontSize"
     static let defaultCounterFontSizeKey = "CounterFontSize"
+    static let defaultToolKey = "DefaultTool"
+    static let lastUsedToolKey = "LastUsedTool"
 }
 
 let colorPalette: [NSColor] = [
@@ -59,6 +61,29 @@ extension UserDefaults {
         }
         set {
             set(Double(newValue), forKey: Self.defaultCounterFontSizeKey)
+        }
+    }
+
+    /// The tool to apply on overlay activation. Defaults to `.lastUsed`, which leaves the
+    /// current in-memory tool untouched.
+    var defaultToolOption: DefaultToolOption {
+        get {
+            let stored = string(forKey: Self.defaultToolKey) ?? ""
+            return DefaultToolOption(rawValue: stored) ?? .lastUsed
+        }
+        set {
+            set(newValue.rawValue, forKey: Self.defaultToolKey)
+        }
+    }
+
+    /// The most recently explicitly selected tool, persisted so it survives app relaunches.
+    var lastUsedTool: ToolType {
+        get {
+            let stored = string(forKey: Self.lastUsedToolKey) ?? ""
+            return ToolType(rawValue: stored) ?? .pen
+        }
+        set {
+            set(newValue.rawValue, forKey: Self.lastUsedToolKey)
         }
     }
 }

--- a/Annotate/GeneralSettingsView.swift
+++ b/Annotate/GeneralSettingsView.swift
@@ -30,9 +30,9 @@ struct GeneralSettingsView: View {
 
     /// Tools offered in the Default Tool picker, excluding Select and Eraser since neither
     /// is a sensible tool to land on when the overlay opens.
-    private static let selectableDefaultTools: [ToolType] = [
-        .pen, .arrow, .line, .highlighter, .rectangle, .circle, .text, .counter,
-    ]
+    private static let selectableDefaultTools = ToolType.allCases.filter {
+        $0 != .select && $0 != .eraser
+    }
 
     var body: some View {
         let minTextSize = Double(textAnnotationFontSizeRange.lowerBound)

--- a/Annotate/GeneralSettingsView.swift
+++ b/Annotate/GeneralSettingsView.swift
@@ -13,6 +13,8 @@ struct GeneralSettingsView: View {
     private var enableBoard = false
     @AppStorage(UserDefaults.persistTextModeKey)
     private var persistTextMode = false
+    @AppStorage(UserDefaults.defaultToolKey)
+    private var defaultToolOption: DefaultToolOption = .lastUsed
     @AppStorage(UserDefaults.defaultTextFontSizeKey)
     private var defaultTextSize: Double = Double(defaultTextAnnotationFontSize)
     @AppStorage(UserDefaults.defaultCounterFontSizeKey)
@@ -25,6 +27,12 @@ struct GeneralSettingsView: View {
     @State private var spotlightSize: Double = Double(CursorHighlightManager.shared.spotlightSize)
     @State private var activeCursorStyle: ActiveCursorStyle = CursorHighlightManager.shared.activeCursorStyle
     @State private var activeCursorSize: Double = Double(CursorHighlightManager.shared.activeCursorSize)
+
+    /// Tools offered in the Default Tool picker, excluding Select and Eraser since neither
+    /// is a sensible tool to land on when the overlay opens.
+    private static let selectableDefaultTools: [ToolType] = [
+        .pen, .arrow, .line, .highlighter, .rectangle, .circle, .text, .counter,
+    ]
 
     var body: some View {
         let minTextSize = Double(textAnnotationFontSizeRange.lowerBound)
@@ -106,6 +114,26 @@ struct GeneralSettingsView: View {
                         description: "Stay in text mode after pressing Enter",
                         isOn: $persistTextMode
                     )
+
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Default Tool")
+                                .font(.system(size: 13, weight: .semibold))
+                            Text("Tool selected each time the overlay is activated")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Picker("", selection: $defaultToolOption) {
+                            Text("Last Used").tag(DefaultToolOption.lastUsed)
+                            ForEach(Self.selectableDefaultTools, id: \.self) { tool in
+                                Text(tool.displayName).tag(DefaultToolOption.tool(tool))
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                        .frame(width: 160, alignment: .trailing)
+                    }
                 }
 
                 Divider()

--- a/Annotate/Models.swift
+++ b/Annotate/Models.swift
@@ -2,16 +2,16 @@ import Cocoa
 
 /// Represents the available tools for annotation.
 enum ToolType: String, CaseIterable {
-    case pen = "pen"
-    case arrow = "arrow"
-    case line = "line"
-    case highlighter = "highlighter"
-    case rectangle = "rectangle"
-    case circle = "circle"
-    case text = "text"
-    case counter = "counter"
-    case select = "select"
-    case eraser = "eraser"
+    case pen
+    case arrow
+    case line
+    case highlighter
+    case rectangle
+    case circle
+    case text
+    case counter
+    case select
+    case eraser
 
     var displayName: String {
         switch self {
@@ -31,7 +31,7 @@ enum ToolType: String, CaseIterable {
 
 /// Which tool becomes active each time the overlay is activated. `.lastUsed` keeps the
 /// in-memory tool as-is (the pre-existing behavior); a specific tool always resets to it.
-enum DefaultToolOption: RawRepresentable, Equatable, Hashable {
+enum DefaultToolOption: RawRepresentable, Hashable {
     case lastUsed
     case tool(ToolType)
 

--- a/Annotate/Models.swift
+++ b/Annotate/Models.swift
@@ -1,17 +1,17 @@
 import Cocoa
 
 /// Represents the available tools for annotation.
-enum ToolType {
-    case pen
-    case arrow
-    case line
-    case highlighter
-    case rectangle
-    case circle
-    case text
-    case counter
-    case select
-    case eraser
+enum ToolType: String, CaseIterable {
+    case pen = "pen"
+    case arrow = "arrow"
+    case line = "line"
+    case highlighter = "highlighter"
+    case rectangle = "rectangle"
+    case circle = "circle"
+    case text = "text"
+    case counter = "counter"
+    case select = "select"
+    case eraser = "eraser"
 
     var displayName: String {
         switch self {
@@ -25,6 +25,30 @@ enum ToolType {
         case .counter: return "Counter"
         case .eraser: return "Eraser"
         case .select: return "Select"
+        }
+    }
+}
+
+/// Which tool becomes active each time the overlay is activated. `.lastUsed` keeps the
+/// in-memory tool as-is (the pre-existing behavior); a specific tool always resets to it.
+enum DefaultToolOption: RawRepresentable, Equatable, Hashable {
+    case lastUsed
+    case tool(ToolType)
+
+    var rawValue: String {
+        switch self {
+        case .lastUsed: return "lastUsed"
+        case .tool(let tool): return tool.rawValue
+        }
+    }
+
+    init?(rawValue: String) {
+        if rawValue == "lastUsed" {
+            self = .lastUsed
+        } else if let tool = ToolType(rawValue: rawValue) {
+            self = .tool(tool)
+        } else {
+            return nil
         }
     }
 }

--- a/AnnotateTests/AppDelegateTests.swift
+++ b/AnnotateTests/AppDelegateTests.swift
@@ -386,4 +386,72 @@ final class AppDelegateTests: XCTestCase, Sendable {
         XCTAssertEqual(overlayWindow.overlayView.currentTool, .line)
         XCTAssertEqual(overlayWindow.overlayView.previousTool, previousToolBefore, "previousTool should remain unchanged when not switching to text mode")
     }
+
+    // MARK: - Default Tool Tests
+
+    func testSwitchToolPersistsLastUsedTool() {
+        appDelegate.enableRectangleMode(NSMenuItem())
+        XCTAssertEqual(testDefaults.lastUsedTool, .rectangle, "Explicitly switching tools should persist the choice as last used")
+
+        appDelegate.enableHighlighterMode(NSMenuItem())
+        XCTAssertEqual(testDefaults.lastUsedTool, .highlighter)
+    }
+
+    func testApplyConfiguredDefaultToolAppliesSpecificTool() {
+        guard let overlayWindow = appDelegate.overlayWindows.values.first else {
+            XCTFail("No overlay window available")
+            return
+        }
+
+        testDefaults.defaultToolOption = .tool(.rectangle)
+        appDelegate.enableArrowMode(NSMenuItem())  // start on a different tool than the configured default
+        XCTAssertEqual(overlayWindow.overlayView.currentTool, .arrow)
+
+        appDelegate.applyConfiguredDefaultTool()
+
+        for window in appDelegate.overlayWindows.values {
+            XCTAssertEqual(window.overlayView.currentTool, .rectangle, "Activation should reset the tool to the configured default")
+        }
+
+        if let menu = appDelegate.statusItem.menu,
+            let currentToolItem = menu.item(at: 3)  // Index 3 is "Current Tool" menu item
+        {
+            XCTAssertEqual(currentToolItem.title, "Current Tool: Rectangle")
+        }
+    }
+
+    func testApplyConfiguredDefaultToolDoesNothingForLastUsed() {
+        guard let overlayWindow = appDelegate.overlayWindows.values.first else {
+            XCTFail("No overlay window available")
+            return
+        }
+
+        XCTAssertEqual(testDefaults.defaultToolOption, .lastUsed, "Default should be Last Used until the setting is touched")
+
+        appDelegate.enableArrowMode(NSMenuItem())
+        XCTAssertEqual(overlayWindow.overlayView.currentTool, .arrow)
+
+        appDelegate.applyConfiguredDefaultTool()
+
+        XCTAssertEqual(overlayWindow.overlayView.currentTool, .arrow, "Last Used should preserve whatever tool was already active")
+    }
+
+    func testLaunchRestoresPersistedLastUsedTool() {
+        testDefaults.lastUsedTool = .highlighter
+
+        let appDelegate = AppDelegate(userDefaults: testDefaults)
+        appDelegate.applicationDidFinishLaunching(
+            Notification(name: NSApplication.didFinishLaunchingNotification))
+
+        for window in appDelegate.overlayWindows.values {
+            XCTAssertEqual(window.overlayView.currentTool, .highlighter, "Overlay windows should restore the persisted last-used tool on launch")
+        }
+    }
+
+    func testLaunchDefaultsToPenWhenNoLastUsedToolSaved() {
+        // testDefaults is a fresh suite with no LastUsedTool key set (see setUp).
+        for window in appDelegate.overlayWindows.values {
+            XCTAssertEqual(window.overlayView.currentTool, .pen, "Should fall back to .pen when no last-used tool was saved")
+        }
+    }
 }

--- a/AnnotateTests/AppDelegateTests.swift
+++ b/AnnotateTests/AppDelegateTests.swift
@@ -420,6 +420,24 @@ final class AppDelegateTests: XCTestCase, Sendable {
         }
     }
 
+    func testApplyConfiguredDefaultToolSkipsWhenToolAlreadyActive() {
+        guard let overlayWindow = appDelegate.overlayWindows.values.first else {
+            XCTFail("No overlay window available")
+            return
+        }
+
+        appDelegate.enableRectangleMode(NSMenuItem())
+        testDefaults.defaultToolOption = .tool(.rectangle)
+        testDefaults.lastUsedTool = .highlighter
+
+        appDelegate.applyConfiguredDefaultTool()
+
+        XCTAssertEqual(overlayWindow.overlayView.currentTool, .rectangle)
+        XCTAssertEqual(
+            testDefaults.lastUsedTool, .highlighter,
+            "Applying a default tool that is already active should be a no-op (no switchTool, no tool feedback)")
+    }
+
     func testApplyConfiguredDefaultToolDoesNothingForLastUsed() {
         guard let overlayWindow = appDelegate.overlayWindows.values.first else {
             XCTFail("No overlay window available")

--- a/AnnotateTests/AppDelegateTests.swift
+++ b/AnnotateTests/AppDelegateTests.swift
@@ -464,6 +464,12 @@ final class AppDelegateTests: XCTestCase, Sendable {
         for window in appDelegate.overlayWindows.values {
             XCTAssertEqual(window.overlayView.currentTool, .highlighter, "Overlay windows should restore the persisted last-used tool on launch")
         }
+
+        if let menu = appDelegate.statusItem.menu,
+            let currentToolItem = menu.item(at: 3)  // Index 3 is "Current Tool" menu item
+        {
+            XCTAssertEqual(currentToolItem.title, "Current Tool: Highlighter", "Menu should reflect the restored tool, not the hardcoded default")
+        }
     }
 
     func testLaunchDefaultsToPenWhenNoLastUsedToolSaved() {

--- a/AnnotateTests/AppDelegateTests.swift
+++ b/AnnotateTests/AppDelegateTests.swift
@@ -454,4 +454,33 @@ final class AppDelegateTests: XCTestCase, Sendable {
             XCTAssertEqual(window.overlayView.currentTool, .pen, "Should fall back to .pen when no last-used tool was saved")
         }
     }
+
+    func testInternalToolRestoreDoesNotOverwriteLastUsedTool() {
+        guard let overlayWindow = appDelegate.overlayWindows.values.first else {
+            XCTFail("No overlay window available")
+            return
+        }
+
+        // restorePreviousTool reads persistTextMode from UserDefaults.standard, so pin it
+        // to false for this test and restore whatever was there afterwards.
+        let savedPersistTextMode = UserDefaults.standard.object(forKey: UserDefaults.persistTextModeKey)
+        UserDefaults.standard.set(false, forKey: UserDefaults.persistTextModeKey)
+        defer {
+            if let saved = savedPersistTextMode {
+                UserDefaults.standard.set(saved, forKey: UserDefaults.persistTextModeKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaults.persistTextModeKey)
+            }
+        }
+
+        appDelegate.enablePenMode(NSMenuItem())
+        appDelegate.enableTextMode(NSMenuItem())
+        XCTAssertEqual(testDefaults.lastUsedTool, .text, "Explicitly switching to text should persist it as last used")
+        XCTAssertEqual(overlayWindow.overlayView.previousTool, .pen)
+
+        overlayWindow.overlayView.restorePreviousTool()
+
+        XCTAssertEqual(overlayWindow.overlayView.currentTool, .pen, "Finishing a text annotation should restore the previous tool")
+        XCTAssertEqual(testDefaults.lastUsedTool, .text, "Internal tool restores should not overwrite the persisted last-used tool")
+    }
 }

--- a/AnnotateTests/ModelTests.swift
+++ b/AnnotateTests/ModelTests.swift
@@ -177,7 +177,41 @@ final class ModelTests: XCTestCase {
             uniqueTools.insert(toolString)
         }
     }
-    
+
+    func testToolTypeRawValueRoundTrip() {
+        for tool in ToolType.allCases {
+            XCTAssertEqual(ToolType(rawValue: tool.rawValue), tool)
+        }
+        XCTAssertNil(ToolType(rawValue: "notATool"))
+    }
+
+    func testDefaultToolOptionRawValueRoundTrip() {
+        XCTAssertEqual(DefaultToolOption(rawValue: "lastUsed"), .lastUsed)
+        XCTAssertEqual(DefaultToolOption(rawValue: "rectangle"), .tool(.rectangle))
+        XCTAssertEqual(DefaultToolOption.lastUsed.rawValue, "lastUsed")
+        XCTAssertEqual(DefaultToolOption.tool(.rectangle).rawValue, "rectangle")
+        XCTAssertNil(DefaultToolOption(rawValue: "notATool"))
+    }
+
+    func testLastUsedToolDefaultsAndPersists() {
+        let defaults = TestUserDefaults.create()
+        XCTAssertEqual(defaults.lastUsedTool, .pen, "Should fall back to .pen when nothing is saved")
+
+        defaults.lastUsedTool = .highlighter
+        XCTAssertEqual(defaults.lastUsedTool, .highlighter)
+    }
+
+    func testDefaultToolOptionDefaultsAndPersists() {
+        let defaults = TestUserDefaults.create()
+        XCTAssertEqual(defaults.defaultToolOption, .lastUsed, "Should default to .lastUsed when nothing is saved")
+
+        defaults.defaultToolOption = .tool(.counter)
+        XCTAssertEqual(defaults.defaultToolOption, .tool(.counter))
+
+        defaults.defaultToolOption = .lastUsed
+        XCTAssertEqual(defaults.defaultToolOption, .lastUsed)
+    }
+
     func testLineWithLineWidth() {
         let start = NSPoint(x: 10, y: 20)
         let end = NSPoint(x: 50, y: 60)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ brew install --cask annotate
 
 1. Launch Annotate.
 2. Press the global hotkey (configurable in Settings) to toggle the overlay.
-3. Start annotating with the default pen tool.
+3. Start annotating with the pen tool (Annotate remembers your last-used tool, or set a fixed default in Settings).
 4. Press <kbd>Esc</kbd> to exit the overlay.
 
 > [!TIP]
@@ -322,8 +322,12 @@ Settings are organized into two tabs: **General** and **Shortcuts**.
 - **Clear Drawings on Toggle**: Automatically clear all drawings when activating Annotate.
 - **Hide Tool Feedback**: Disable visual feedback when switching tools.
 - **Show in Dock**: Display Annotate icon in the Dock.
+- **Persist Text Mode**: Stay in text mode after pressing Enter.
+- **Default Tool**: Choose which tool is selected each time the overlay is activated (defaults to last used).
 - **Enable Board**: Show whiteboard or blackboard background.
 - **Board Opacity**: Adjust board background transparency (10-100%).
+- **Default Text Size**: Adjust the default font size for text annotations (12-48pt).
+- **Default Counter Size**: Adjust the default size for counter annotations (12-60pt).
 - **Cursor Style**: Choose how the cursor appears while annotating (None, Outline, Circle, Crosshair).
 - **Cursor Size**: Adjust the size of circle or crosshair cursor indicators (8-24px).
 - **Enable Cursor Spotlight**: Show a visual spotlight following your cursor.


### PR DESCRIPTION
## Overview

Adds a **Default Tool** option to Settings that controls which tool is active each time the overlay is activated, and makes the last-used tool persist across app relaunches.

Resolves #59

## Motivation

The selected tool previously lived only in memory, so every app relaunch reset it to the pen tool. Users who reach for the same tool every session (like Rectangle for callouts) had to manually switch on every activation. This PR gives them a choice:

- **Last Used** (default): keeps the current behavior and now survives relaunches.
- **Any specific tool**: the overlay starts on that tool every time it's activated, regardless of what was used last.

## Screenshots

<!-- Settings > General showing the new Default Tool picker -->

<img width="712" height="749" alt="image" src="https://github.com/user-attachments/assets/339a534f-0ffb-4f0b-88c1-2a976d5137f4" />


## Changes

### Default Tool Setting

- **Models.swift** - `ToolType` gains `String` raw values and `CaseIterable`; new `DefaultToolOption` enum (`.lastUsed` or `.tool(ToolType)`) that round-trips through `UserDefaults` and works with `@AppStorage`
- **Constants.swift** - New `defaultToolKey` / `lastUsedToolKey` keys with typed accessors following the existing pattern
- **AppDelegate.swift** - Restores the persisted tool at launch and for newly connected screens, persists explicit tool switches, and applies the configured default on overlay activation via `applyConfiguredDefaultTool()`
- **GeneralSettingsView.swift** - "Default Tool" picker in the Application section with "Last Used" first; Select and Eraser are excluded since neither is a sensible starting tool

### Cleanup

- **AppDelegate.swift** - `switchTool(to:)` now updates the current tool menu item itself, removing the duplicated pairing and hardcoded label strings from all 11 call sites

### Docs

- **README.md** - Documents the new setting, updates Quick Start for last-used persistence, and backfills missing General Settings entries (Persist Text Mode, Default Text Size, Default Counter Size)

## Breaking Changes

None

## Testing

- [x] 9 new unit tests covering raw-value round-trips, UserDefaults persistence, activation behavior, launch restore, and the guard that internal tool restores (text finalize) don't overwrite the persisted last-used tool
- [x] Full suite passes: 361 tests, only the known pre-existing `testColorPicker` headless flake fails
- [x] Manual testing: settings UI, per-activation default application, last-used persistence across relaunch, menu tool selection not being stomped by the configured default


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Default Tool** setting to choose which annotation tool opens when the overlay is enabled.
  * The app now persists the **last used tool** and restores it on launch/when overlays reappear.
* **Bug Fixes**
  * Improved tool switching so overlays and the **Current Tool** status stay in sync across screen changes.
* **Documentation**
  * Updated Quick Start and General Settings to describe the new **Default Tool** behavior.
* **Tests**
  * Added coverage for tool persistence, default-tool application, and raw-value behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->