### PR TITLE
fix(tools): Don't persist last-used tool when applying the default

### DIFF
--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -539,12 +539,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
         }
     }
 
-    func switchTool(to tool: ToolType) {
+    func switchTool(to tool: ToolType, persist: Bool = true) {
         if alwaysOnMode {
             toggleAlwaysOnMode()
         }
 
-        userDefaults.lastUsedTool = tool
+        if persist {
+            userDefaults.lastUsedTool = tool
+        }
 
         overlayWindows.values.forEach { window in
             if window.overlayView.currentTool == .select && tool != .select {
@@ -567,11 +569,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
     /// Applies the configured default tool when the overlay activates. Does nothing when the
     /// setting is "Last used", leaving whatever tool is already current in place, or when
     /// every window is already on the configured tool (avoids showing tool feedback on
-    /// every activation).
+    /// every activation). Applying the default is not an explicit tool selection, so it does
+    /// not overwrite the persisted last-used tool.
     func applyConfiguredDefaultTool() {
         guard case .tool(let tool) = userDefaults.defaultToolOption else { return }
         guard overlayWindows.values.contains(where: { $0.overlayView.currentTool != tool }) else { return }
-        switchTool(to: tool)
+        switchTool(to: tool, persist: false)
     }
 
     @objc func enableArrowMode(_ sender: NSMenuItem) {

--- a/AnnotateTests/AppDelegateTests.swift
+++ b/AnnotateTests/AppDelegateTests.swift
@@ -438,6 +438,23 @@ final class AppDelegateTests: XCTestCase, Sendable {
             "Applying a default tool that is already active should be a no-op (no switchTool, no tool feedback)")
     }
 
+    func testApplyConfiguredDefaultToolDoesNotOverwriteLastUsedTool() {
+        guard let overlayWindow = appDelegate.overlayWindows.values.first else {
+            XCTFail("No overlay window available")
+            return
+        }
+
+        appDelegate.enableHighlighterMode(NSMenuItem())
+        testDefaults.defaultToolOption = .tool(.rectangle)
+
+        appDelegate.applyConfiguredDefaultTool()
+
+        XCTAssertEqual(overlayWindow.overlayView.currentTool, .rectangle)
+        XCTAssertEqual(
+            testDefaults.lastUsedTool, .highlighter,
+            "Applying the configured default is not an explicit selection and must not overwrite the persisted last-used tool")
+    }
+
     func testApplyConfiguredDefaultToolDoesNothingForLastUsed() {
         guard let overlayWindow = appDelegate.overlayWindows.values.first else {
             XCTFail("No overlay window available")

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Settings are organized into two tabs: **General** and **Shortcuts**.
 
 - **Activation Shortcut**: Set a global keyboard shortcut to toggle Annotate.
 - **Always-On Mode**: Set a global keyboard shortcut to toggle always-on mode.
-- **Clear Drawings on Toggle**: Automatically clear all drawings when activating Annotate.
+- **Clear Drawings on Toggle**: Automatically clear all drawings when toggling the overlay off.
 - **Hide Tool Feedback**: Disable visual feedback when switching tools.
 - **Show in Dock**: Display Annotate icon in the Dock.
 - **Persist Text Mode**: Stay in text mode after pressing Enter.
@@ -331,7 +331,10 @@ Settings are organized into two tabs: **General** and **Shortcuts**.
 - **Cursor Style**: Choose how the cursor appears while annotating (None, Outline, Circle, Crosshair).
 - **Cursor Size**: Adjust the size of circle or crosshair cursor indicators (8-24px).
 - **Enable Cursor Spotlight**: Show a visual spotlight following your cursor.
-- **Enable Click Effect**: Show ripple effect on mouse clicks.
+- **Spotlight Size**: Adjust the size of the cursor spotlight (30-100).
+- **Enable Click Effect**: Show a ripple on click and a highlight while holding.
+- **Click Effect Size**: Adjust the size of the click ripple and hold highlight (30-100).
+- **Effect Color**: Choose the color used for the spotlight and click effects from the color palette.
 
 ### Keyboard Shortcuts
 


### PR DESCRIPTION
## Overview

Fixes the configured default tool overwriting the persisted last-used tool on every overlay activation, and completes the General Settings list in the README.

Follow-up to #60.

## Motivation

With a fixed default tool configured, activating the overlay routed through `switchTool`, which persisted the applied default as the last-used tool. Switching the setting back to Last Used (or relaunching) then restored the old default instead of the tool the user actually picked last. Applying the default is an automatic reset, not an explicit selection, so it should leave the persisted preference untouched.

## Changes

### Default Tool Persistence

- **AppDelegate.swift** - `switchTool(to:)` gains a `persist` parameter (default `true`), and `applyConfiguredDefaultTool()` opts out so automatic application no longer overwrites `lastUsedTool`; explicit tool switches behave exactly as before
- **AppDelegateTests.swift** - New `testApplyConfiguredDefaultToolDoesNotOverwriteLastUsedTool` pins that applying the default preserves the persisted last-used tool

### Docs

- **README.md** - Backfills the missing Spotlight Size, Click Effect Size, and Effect Color entries in General Settings, aligns Clear Drawings on Toggle with the in-app description, and mentions the hold highlight in Enable Click Effect

## Breaking Changes

None

## Testing

- [x] New unit test covering that applying the configured default preserves `lastUsedTool`
- [x] `AppDelegateTests` passes: 27 tests, 0 failures (known headless `testColorPicker` flake excluded)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changing the default drawing tool no longer overwrites the previously used tool.
  * “Clear Drawings on Toggle” now clearly applies when turning the overlay off, not when turning it on.

* **Documentation**
  * Expanded the settings guide with more detail on click effect options, including size, enablement, and color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->