### PR TITLE
feat(cursor): Add option to hide spotlight when overlay is inactive

### DIFF
--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -382,6 +382,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
         }
 
         updateCursorHighlightWindowsForScreenChange()
+        CursorHighlightManager.shared.overlayVisibilityChanged()
     }
 
     func getCurrentScreen() -> NSScreen? {
@@ -501,6 +502,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
                 overlayWindow.orderOut(nil)
             }
         }
+        CursorHighlightManager.shared.overlayVisibilityChanged()
 
         let iconColor = alwaysOnMode
             ? currentColor.withAlphaComponent(0.7)

--- a/Annotate/Constants.swift
+++ b/Annotate/Constants.swift
@@ -20,6 +20,7 @@ extension UserDefaults {
     static let clickRippleSizeKey = "ClickRippleSize"
     static let cursorHighlightEnabledKey = "CursorHighlightEnabled"
     static let spotlightSizeKey = "SpotlightSize"
+    static let spotlightRequiresOverlayKey = "SpotlightRequiresOverlay"
     static let activeCursorStyleKey = "ActiveCursorStyle"
     static let activeCursorSizeKey = "ActiveCursorSize"
     static let persistTextModeKey = "PersistTextMode"

--- a/Annotate/CursorHighlightManager.swift
+++ b/Annotate/CursorHighlightManager.swift
@@ -125,6 +125,14 @@ class CursorHighlightManager: @unchecked Sendable {
         }
     }
 
+    var spotlightRequiresOverlay: Bool {
+        get { userDefaults.bool(forKey: UserDefaults.spotlightRequiresOverlayKey) }
+        set {
+            userDefaults.set(newValue, forKey: UserDefaults.spotlightRequiresOverlayKey)
+            notifyStateChanged()
+        }
+    }
+
     var spotlightSize: CGFloat {
         get {
             let stored = userDefaults.double(forKey: UserDefaults.spotlightSizeKey)
@@ -194,8 +202,14 @@ class CursorHighlightManager: @unchecked Sendable {
 
     var shouldShowRing: Bool { isActive && isMouseDown }
 
+    /// Spotlight preference is on and its overlay gate is satisfied; ignores transient mouse-down suppression.
+    /// The gate is deliberately global: any visible overlay keeps the spotlight following the cursor on every screen.
+    var cursorHighlightAvailable: Bool {
+        cursorHighlightEnabled && (!spotlightRequiresOverlay || hasAnyActiveOverlay())
+    }
+
     var shouldShowCursorHighlight: Bool {
-        cursorHighlightEnabled && !isMouseDown
+        cursorHighlightAvailable && !isMouseDown
     }
 
     var hasActiveAnimation: Bool {

--- a/Annotate/CursorHighlightWindow.swift
+++ b/Annotate/CursorHighlightWindow.swift
@@ -123,7 +123,7 @@ class CursorHighlightWindow: NSPanel {
     func updateVisibility() {
         let manager = CursorHighlightManager.shared
 
-        if manager.isActive || manager.cursorHighlightEnabled || manager.shouldShowActiveCursorOnAnyScreen() {
+        if manager.isActive || manager.cursorHighlightAvailable || manager.shouldShowActiveCursorOnAnyScreen() {
             orderFront(nil)
             startAnimationLoop()
         } else {

--- a/Annotate/CursorHighlightWindow.swift
+++ b/Annotate/CursorHighlightWindow.swift
@@ -127,6 +127,8 @@ class CursorHighlightWindow: NSPanel {
             orderFront(nil)
             startAnimationLoop()
         } else {
+            // Zero the spotlight layer before ordering out to avoid a stale flash on the next orderFront.
+            highlightView.updateSpotlightPosition()
             orderOut(nil)
             stopAnimationLoop()
         }

--- a/Annotate/CursorSettingsView.swift
+++ b/Annotate/CursorSettingsView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct CursorSettingsView: View {
     @State private var clickEffectsEnabled: Bool = CursorHighlightManager.shared.clickEffectsEnabled
     @State private var cursorHighlightEnabled: Bool = CursorHighlightManager.shared.cursorHighlightEnabled
+    @State private var spotlightRequiresOverlay: Bool = CursorHighlightManager.shared.spotlightRequiresOverlay
     @State private var effectColor: Color = Color(CursorHighlightManager.shared.effectColor)
     @State private var effectSize: Double = Double(CursorHighlightManager.shared.effectSize)
     @State private var spotlightSize: Double = Double(CursorHighlightManager.shared.spotlightSize)
@@ -82,6 +83,14 @@ struct CursorSettingsView: View {
                             CursorHighlightManager.shared.spotlightSize = CGFloat(newValue)
                         }
                     }
+
+                    Toggle(isOn: $spotlightRequiresOverlay) {
+                        Text("Only Show While Annotating")
+                        Text("Turn off the spotlight when the overlay is deactivated")
+                    }
+                    .onChange(of: spotlightRequiresOverlay) { _, _ in
+                        CursorHighlightManager.shared.spotlightRequiresOverlay = spotlightRequiresOverlay
+                    }
                 }
 
                 Toggle(isOn: $clickEffectsEnabled) {
@@ -146,6 +155,7 @@ struct CursorSettingsView: View {
     private func syncState() {
         clickEffectsEnabled = CursorHighlightManager.shared.clickEffectsEnabled
         cursorHighlightEnabled = CursorHighlightManager.shared.cursorHighlightEnabled
+        spotlightRequiresOverlay = CursorHighlightManager.shared.spotlightRequiresOverlay
         effectColor = Color(CursorHighlightManager.shared.effectColor)
         effectSize = Double(CursorHighlightManager.shared.effectSize)
         spotlightSize = Double(CursorHighlightManager.shared.spotlightSize)

--- a/Annotate/CursorSettingsView.swift
+++ b/Annotate/CursorSettingsView.swift
@@ -86,7 +86,7 @@ struct CursorSettingsView: View {
 
                     Toggle(isOn: $spotlightRequiresOverlay) {
                         Text("Only Show While Annotating")
-                        Text("Turn off the spotlight when the overlay is deactivated")
+                        Text("Show the spotlight only while the overlay is active")
                     }
                     .onChange(of: spotlightRequiresOverlay) { _, _ in
                         CursorHighlightManager.shared.spotlightRequiresOverlay = spotlightRequiresOverlay

--- a/AnnotateTests/CursorHighlightManagerTests.swift
+++ b/AnnotateTests/CursorHighlightManagerTests.swift
@@ -145,25 +145,27 @@ final class CursorHighlightManagerTests: XCTestCase {
         overlayWindow.orderFront(nil)
         try XCTSkipUnless(overlayWindow.isVisible, "Overlay window is not visible in this test environment")
 
-        manager.cursorHighlightEnabled = true
-        manager.spotlightRequiresOverlay = true
+        withExtendedLifetime(appDelegate) {
+            manager.cursorHighlightEnabled = true
+            manager.spotlightRequiresOverlay = true
 
-        XCTAssertTrue(
-            manager.cursorHighlightAvailable,
-            "cursorHighlightAvailable should be true when the gate is on and an overlay is visible"
-        )
+            XCTAssertTrue(
+                manager.cursorHighlightAvailable,
+                "cursorHighlightAvailable should be true when the gate is on and an overlay is visible"
+            )
 
-        manager.isMouseDown = true
-        XCTAssertFalse(
-            manager.shouldShowCursorHighlight,
-            "shouldShowCursorHighlight should be false while the mouse is down"
-        )
+            manager.isMouseDown = true
+            XCTAssertFalse(
+                manager.shouldShowCursorHighlight,
+                "shouldShowCursorHighlight should be false while the mouse is down"
+            )
 
-        manager.isMouseDown = false
-        XCTAssertTrue(
-            manager.shouldShowCursorHighlight,
-            "shouldShowCursorHighlight should be true when the gate is satisfied and the mouse is up"
-        )
+            manager.isMouseDown = false
+            XCTAssertTrue(
+                manager.shouldShowCursorHighlight,
+                "shouldShowCursorHighlight should be true when the gate is satisfied and the mouse is up"
+            )
+        }
     }
 
     // MARK: - clickEffectsEnabled Tests
@@ -332,6 +334,14 @@ final class CursorHighlightManagerTests: XCTestCase {
         let expectation = expectation(forNotification: .cursorHighlightStateChanged, object: nil)
 
         manager.clickEffectsEnabled = true
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testSettingSpotlightRequiresOverlayPostsNotification() {
+        let expectation = expectation(forNotification: .cursorHighlightStateChanged, object: nil)
+
+        manager.spotlightRequiresOverlay = true
 
         wait(for: [expectation], timeout: 1.0)
     }

--- a/AnnotateTests/CursorHighlightManagerTests.swift
+++ b/AnnotateTests/CursorHighlightManagerTests.swift
@@ -11,11 +11,13 @@ final class CursorHighlightManagerTests: XCTestCase {
         super.setUp()
         testDefaults = TestUserDefaults.create()
         manager = CursorHighlightManager(userDefaults: testDefaults)
+        AppDelegate.shared = nil
     }
 
     override func tearDown() {
         TestUserDefaults.removeSuite()
         manager = nil
+        AppDelegate.shared = nil
         super.tearDown()
     }
 
@@ -81,6 +83,86 @@ final class CursorHighlightManagerTests: XCTestCase {
         XCTAssertFalse(
             manager.shouldShowCursorHighlight,
             "shouldShowCursorHighlight should return false when both conditions are not met"
+        )
+    }
+
+    // MARK: - spotlightRequiresOverlay Tests
+
+    func testSpotlightRequiresOverlayDefaultsToFalse() {
+        XCTAssertFalse(manager.spotlightRequiresOverlay, "spotlightRequiresOverlay should default to false")
+    }
+
+    func testSpotlightRequiresOverlaySetToTruePersistsToUserDefaults() {
+        manager.spotlightRequiresOverlay = true
+
+        XCTAssertTrue(manager.spotlightRequiresOverlay, "spotlightRequiresOverlay should be true after setting")
+        let persistedValue = testDefaults.bool(forKey: UserDefaults.spotlightRequiresOverlayKey)
+        XCTAssertTrue(persistedValue, "spotlightRequiresOverlay should be persisted to UserDefaults")
+    }
+
+    // MARK: - cursorHighlightAvailable Computed Property Tests
+
+    func testCursorHighlightAvailableMatchesCursorHighlightEnabledWhenGateIsOff() {
+        manager.spotlightRequiresOverlay = false
+
+        manager.cursorHighlightEnabled = true
+        XCTAssertTrue(
+            manager.cursorHighlightAvailable,
+            "cursorHighlightAvailable should be true when the spotlight is enabled and the gate is off"
+        )
+
+        manager.cursorHighlightEnabled = false
+        XCTAssertFalse(
+            manager.cursorHighlightAvailable,
+            "cursorHighlightAvailable should be false when the spotlight is disabled regardless of the gate"
+        )
+    }
+
+    func testCursorHighlightAvailableFalseWhenGateOnAndNoActiveOverlay() {
+        manager.cursorHighlightEnabled = true
+        manager.spotlightRequiresOverlay = true
+
+        // AppDelegate.shared is nil in unit tests, so hasAnyActiveOverlay() is false.
+        XCTAssertFalse(
+            manager.cursorHighlightAvailable,
+            "cursorHighlightAvailable should be false when spotlightRequiresOverlay is true and no overlay is active"
+        )
+    }
+
+    func testCursorHighlightAvailableTrueWhenGateOnAndOverlayVisible() throws {
+        let appDelegate = MockAppDelegate()
+        let screen = try XCTUnwrap(NSScreen.main)
+        let overlayWindow = OverlayWindow(
+            contentRect: screen.frame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        appDelegate.overlayWindows[screen] = overlayWindow
+        AppDelegate.shared = appDelegate
+        defer { overlayWindow.orderOut(nil) }
+
+        overlayWindow.orderFront(nil)
+        try XCTSkipUnless(overlayWindow.isVisible, "Overlay window is not visible in this test environment")
+
+        manager.cursorHighlightEnabled = true
+        manager.spotlightRequiresOverlay = true
+
+        XCTAssertTrue(
+            manager.cursorHighlightAvailable,
+            "cursorHighlightAvailable should be true when the gate is on and an overlay is visible"
+        )
+
+        manager.isMouseDown = true
+        XCTAssertFalse(
+            manager.shouldShowCursorHighlight,
+            "shouldShowCursorHighlight should be false while the mouse is down"
+        )
+
+        manager.isMouseDown = false
+        XCTAssertTrue(
+            manager.shouldShowCursorHighlight,
+            "shouldShowCursorHighlight should be true when the gate is satisfied and the mouse is up"
         )
     }
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Settings are organized into a sidebar with five panes: **General**, **Tools**, *
 - **Cursor Size**: Adjust the size of circle or crosshair cursor indicators (8-24px).
 - **Enable Cursor Spotlight**: Show a visual spotlight following your cursor.
 - **Spotlight Size**: Adjust the size of the cursor spotlight (30-100).
+- **Only Show While Annotating**: Show the spotlight only while the overlay is active.
 - **Enable Click Effect**: Show a ripple on click and a highlight while holding.
 - **Click Effect Size**: Adjust the size of the click ripple and hold highlight (30-100).
 - **Effect Color**: Choose the color used for the spotlight and click effects from the color palette.


### PR DESCRIPTION
## Overview

Adds an opt-in setting that hides the cursor spotlight whenever the annotation overlay is inactive, so the spotlight follows the overlay instead of staying on all the time.

Resolves #52

## Motivation

The cursor spotlight is currently all-or-nothing: once enabled in Settings, it follows the cursor whether or not the overlay is active. That is distracting during normal work, and the only way to stop it is to open Settings and turn the whole feature off, which loses the preference.

This adds a nested "Only Show While Annotating" toggle so the spotlight appears when the overlay is activated and disappears when it is dismissed, without touching the saved spotlight preference.

## Changes

### Spotlight Gate

- **CursorHighlightManager.swift** - Adds the `spotlightRequiresOverlay` preference and a derived `cursorHighlightAvailable` gate (`cursorHighlightEnabled && (!spotlightRequiresOverlay || hasAnyActiveOverlay())`). Derived state avoids mutating the persisted `CursorHighlightEnabled` flag on every overlay transition, so the user's Settings choice survives and reactivation is automatic.
- **CursorHighlightWindow.swift** - `updateVisibility()` now checks `cursorHighlightAvailable` instead of `cursorHighlightEnabled`.
- **Constants.swift** - Adds the `SpotlightRequiresOverlay` UserDefaults key.

### Overlay Visibility Notifications

- **AppDelegate.swift** - Notifies `overlayVisibilityChanged()` from `toggleAlwaysOnMode` and `screenParametersChanged`. Both already changed overlay visibility without posting, which left the new gate stale (for example, unplugging the display that held the only active overlay).

### Settings UI

- **CursorSettingsView.swift** - Adds the "Only Show While Annotating" toggle nested under Spotlight Size, shown only when the spotlight is enabled.

### Tests

- **CursorHighlightManagerTests.swift** - Covers the new preference's default and persistence, and `cursorHighlightAvailable` with the gate off, with the gate on and no overlay, and with the gate on and a visible overlay (including mouse-down suppression). Resets `AppDelegate.shared` in setUp/tearDown so the overlay lookup is deterministic.

## Breaking Changes

None. The setting defaults to off, so existing spotlight behavior is unchanged.

## Testing

- [x] Unit tests pass (380 passed, 0 failed, 1 skipped headless)
- [x] Manual testing: spotlight appears on overlay activation and disappears on dismissal with the toggle on
- [x] Manual testing: spotlight behavior unchanged with the toggle off


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cursor spotlight option that requires an active annotation overlay.
  * Saved and synchronized the new preference in cursor settings.
  * Cursor highlighting now updates when overlay visibility or display settings change.

* **Bug Fixes**
  * Improved spotlight visibility and state restoration during mouse interactions.

* **Documentation**
  * Documented the new cursor spotlight setting.

* **Tests**
  * Added coverage for preference persistence, overlay availability, and mouse interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->