### PR TITLE
Rafkhan/configurable fade time

### DIFF
--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -4,7 +4,9 @@ import Sparkle
 import SwiftUI
 
 @MainActor
-class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverDelegate,
+    NSMenuDelegate
+{
     static weak var shared: AppDelegate?
 
     var statusItem: NSStatusItem!
@@ -285,6 +287,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
             toggleDrawingModeItem.keyEquivalentModifierMask = []
             menu.addItem(toggleDrawingModeItem)
 
+            let fadeTimeItem = NSMenuItem(title: "Fade Time", action: nil, keyEquivalent: "")
+            let fadeTimeMenu = NSMenu()
+            for delay in Self.fadeDelayPresets {
+                let presetItem = NSMenuItem(
+                    title: Self.formatFadeDelay(delay),
+                    action: #selector(setFadeDelay(_:)),
+                    keyEquivalent: "")
+                presetItem.representedObject = delay
+                fadeTimeMenu.addItem(presetItem)
+            }
+            fadeTimeItem.submenu = fadeTimeMenu
+            menu.addItem(fadeTimeItem)
+
             menu.addItem(NSMenuItem.separator())
             
             let currentOverlayModeItem = NSMenuItem(
@@ -307,9 +322,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
             let clearAllItem = NSMenuItem(
                 title: "Clear All",
                 action: #selector(clearAllAnnotations),
-                keyEquivalent: "\u{8}"
+                keyEquivalent: ShortcutManager.shared.getShortcut(for: .clearAll)
             )
-            clearAllItem.keyEquivalentModifierMask = [.option]
+            clearAllItem.keyEquivalentModifierMask = []
             menu.addItem(clearAllItem)
 
             let undoItem = NSMenuItem(
@@ -352,8 +367,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
                     title: "Quit", action: #selector(NSApplication.terminate(_:)),
                     keyEquivalent: "q"))
 
+            menu.delegate = self
             statusItem.menu = menu
+            updateFadeTimeMenuItems()
         }
+    }
+
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        guard menu === statusItem.menu else { return }
+        updateFadeTimeMenuItems()
     }
 
     @objc func screenParametersChanged() {
@@ -705,6 +727,30 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
         overlayWindow.stopFadeLoop()
     }
     
+    static let fadeDelayPresets: [Double] = [0.25, 0.5, 1, 2, 3, 5]
+
+    static func formatFadeDelay(_ delay: Double) -> String {
+        delay == delay.rounded() ? "\(Int(delay))s" : String(format: "%gs", delay)
+    }
+
+    @objc func setFadeDelay(_ sender: NSMenuItem) {
+        guard let delay = sender.representedObject as? Double else { return }
+        userDefaults.fadeDelay = delay
+        updateFadeTimeMenuItems()
+    }
+
+    private func updateFadeTimeMenuItems() {
+        guard let submenu = statusItem.menu?.items.first(where: { $0.title == "Fade Time" })?
+            .submenu
+        else { return }
+
+        let current = userDefaults.fadeDelay
+        for item in submenu.items {
+            guard let delay = item.representedObject as? Double else { continue }
+            item.state = abs(delay - current) < 0.01 ? .on : .off
+        }
+    }
+
     private func updateFadeModeMenuItems(isCurrentlyFadeMode: Bool) {
         guard let menu = statusItem.menu else { return }
         
@@ -799,6 +845,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSPopoverD
                 item.keyEquivalent = ShortcutManager.shared.getShortcut(for: .toggleBoard)
             case #selector(toggleClickEffects(_:)):
                 item.keyEquivalent = ShortcutManager.shared.getShortcut(for: .toggleClickEffects)
+            case #selector(clearAllAnnotations):
+                item.keyEquivalent = ShortcutManager.shared.getShortcut(for: .clearAll)
             default:
                 break
             }

--- a/Annotate/Constants.swift
+++ b/Annotate/Constants.swift
@@ -10,6 +10,7 @@ extension UserDefaults {
     static let clearDrawingsOnStartKey = "ClearDrawingsOnStart"
     static let hideDockIconKey = "HideDockIcon"
     static let fadeModeKey = "FadeMode"
+    static let fadeDelayKey = "FadeDelay"
     static let enableBoardKey = "EnableBoard"
     static let boardOpacityKey = "BoardOpacity"
     static let alwaysOnModeKey = "AlwaysOnMode"
@@ -35,6 +36,11 @@ let colorPalette: [NSColor] = [
     .magenta, .white, .black,
 ]
 
+/// Seconds an annotation holds at full opacity before the fade-out begins
+/// (fade mode only). The fade-out itself takes `OverlayView.fadeOutDuration`.
+let defaultFadeDelay: Double = 0.5
+let fadeDelayRange: ClosedRange<Double> = 0.25...5
+
 let defaultTextAnnotationFontSize: CGFloat = 18
 let textAnnotationFontSizeRange: ClosedRange<CGFloat> = 12...48
 
@@ -44,6 +50,16 @@ let defaultCounterFontSize: CGFloat = 14
 let counterFontSizeRange: ClosedRange<CGFloat> = 12...60
 
 extension UserDefaults {
+    var fadeDelay: TimeInterval {
+        get {
+            let stored = double(forKey: Self.fadeDelayKey)
+            return stored > 0 ? stored : defaultFadeDelay
+        }
+        set {
+            set(newValue, forKey: Self.fadeDelayKey)
+        }
+    }
+
     var textToolFontSize: CGFloat {
         get {
             let stored = double(forKey: Self.defaultTextFontSizeKey)

--- a/Annotate/GeneralSettingsView.swift
+++ b/Annotate/GeneralSettingsView.swift
@@ -12,6 +12,8 @@ struct GeneralSettingsView: View {
     private var persistTextMode = false
     @AppStorage(UserDefaults.defaultToolKey)
     private var defaultToolOption: DefaultToolOption = .lastUsed
+    @AppStorage(UserDefaults.fadeDelayKey)
+    private var fadeDelay = defaultFadeDelay
 
     /// Tools offered in the Default Tool picker, excluding Select and Eraser since neither
     /// is a sensible tool to land on when the overlay opens.
@@ -94,6 +96,24 @@ struct GeneralSettingsView: View {
                     color: .blue,
                     title: "Application",
                     subtitle: "Configure app launch and display options"
+                )
+            }
+
+            Section {
+                SettingsSliderRow(
+                    title: "Fade Delay",
+                    value: $fadeDelay,
+                    range: fadeDelayRange,
+                    step: 0.25,
+                    valueText: { String(format: "%gs", $0) },
+                    boundsText: { String(format: "%gs", $0) }
+                )
+            } header: {
+                SettingsHeader(
+                    icon: "timer",
+                    color: .purple,
+                    title: "Fade Mode",
+                    subtitle: "How long annotations stay on screen before fading out"
                 )
             }
         }

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -98,7 +98,10 @@ class OverlayView: NSView, NSTextFieldDelegate {
     var currentLineWidth: CGFloat = 3.0
 
     var fadeMode: Bool = true
-    let fadeDuration: CFTimeInterval = 1.25
+    /// Full-opacity hold before the fade-out starts; user-configurable in Settings.
+    var fadeDelay: CFTimeInterval { UserDefaults.standard.fadeDelay }
+    let fadeOutDuration: CFTimeInterval = 0.75
+    var fadeDuration: CFTimeInterval { fadeDelay + fadeOutDuration }
     var isReadOnlyMode: Bool = false
 
     private var cursorTrackingArea: NSTrackingArea?
@@ -833,10 +836,8 @@ class OverlayView: NSView, NSTextFieldDelegate {
     }
 
     private func alphaForAge(_ age: CFTimeInterval) -> CGFloat {
-        let fadeDelay = fadeDuration / 2
         if age <= fadeDelay { return 1.0 }
-        let fadeOut = fadeDelay - (age - fadeDelay)
-        return CGFloat(max(0, fadeOut))
+        return CGFloat(max(0, (fadeDuration - age) / fadeOutDuration))
     }
     
     

--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -694,6 +694,9 @@ class OverlayWindow: NSPanel {
             case ShortcutManager.shared.getShortcut(for: .toggleClickEffects):
                 AppDelegate.shared?.toggleClickEffects(nil)
                 return
+            case ShortcutManager.shared.getShortcut(for: .clearAll):
+                AppDelegate.shared?.clearAllAnnotations()
+                return
             default:
                 break
             }

--- a/Annotate/ShortcutManager.swift
+++ b/Annotate/ShortcutManager.swift
@@ -19,6 +19,7 @@ enum ShortcutKey: String, CaseIterable {
     case lineWidthPicker = "w"
     case toggleBoard = "b"
     case toggleClickEffects = "k"
+    case clearAll = "x"
 
     var defaultKey: String { rawValue }
 
@@ -38,6 +39,7 @@ enum ShortcutKey: String, CaseIterable {
         case .lineWidthPicker: return "Line Width"
         case .toggleBoard: return "Toggle Board"
         case .toggleClickEffects: return "Toggle Cursor Highlight"
+        case .clearAll: return "Clear All"
         }
     }
 }

--- a/Annotate/ShortcutsSettingsView.swift
+++ b/Annotate/ShortcutsSettingsView.swift
@@ -140,6 +140,13 @@ struct ShortcutsSettingsView: View {
                     shortcuts: $shortcuts,
                     editingShortcut: $editingShortcut
                 )
+                ShortcutSettingRow(
+                    tool: .clearAll,
+                    label: "Clear All",
+                    description: "Remove all annotations (⌥⌫ also works)",
+                    shortcuts: $shortcuts,
+                    editingShortcut: $editingShortcut
+                )
             } header: {
                 SettingsHeader(
                     icon: "slider.horizontal.3",

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -21,10 +21,25 @@ final class OverlayViewTests: XCTestCase, Sendable {
     }
 
     func testOverlayViewInitialization() {
+        UserDefaults.standard.removeObject(forKey: UserDefaults.fadeDelayKey)
         XCTAssertEqual(overlayView.currentColor, .systemRed)
         XCTAssertEqual(overlayView.currentTool, .pen)
         XCTAssertTrue(overlayView.fadeMode)
         XCTAssertEqual(overlayView.fadeDuration, 1.25)
+    }
+
+    func testFadeDelaySetting() {
+        defer { UserDefaults.standard.removeObject(forKey: UserDefaults.fadeDelayKey) }
+
+        UserDefaults.standard.removeObject(forKey: UserDefaults.fadeDelayKey)
+        XCTAssertEqual(overlayView.fadeDelay, defaultFadeDelay)
+
+        UserDefaults.standard.fadeDelay = 3.0
+        XCTAssertEqual(overlayView.fadeDelay, 3.0)
+        XCTAssertEqual(overlayView.fadeDuration, 3.0 + overlayView.fadeOutDuration)
+    }
+
+    func testOverlayViewInitialEmptyState() {
 
         // Test empty collections
         XCTAssertTrue(overlayView.paths.isEmpty)

--- a/AnnotateTests/ShortcutManagerTests.swift
+++ b/AnnotateTests/ShortcutManagerTests.swift
@@ -152,6 +152,7 @@ final class ShortcutManagerTests: XCTestCase, Sendable {
         XCTAssertEqual(ShortcutKey.lineWidthPicker.defaultKey, "w", "Line Width should be 'w'")
         XCTAssertEqual(ShortcutKey.toggleBoard.defaultKey, "b", "Board should be 'b'")
         XCTAssertEqual(ShortcutKey.toggleClickEffects.defaultKey, "k", "Toggle Cursor Highlight should be 'k'")
+        XCTAssertEqual(ShortcutKey.clearAll.defaultKey, "x", "Clear All should be 'x'")
     }
     
     func testNoShortcutConflicts() {


### PR DESCRIPTION
This PR adds configurable fade times in the settings, as well as a remappable clear all button (I am using x, personally, so I can keep a pen in one hand as I clear the screen!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable Fade Delay setting, adjustable from 0.25 to 5 seconds.
  - Added Fade Time presets to the status bar menu with checkmark indicators.
  - Added a customizable “Clear All” shortcut, defaulting to `X`; Option-Delete remains supported.
  - Updated annotation fading to respect the selected delay.

- **Bug Fixes**
  - Menu shortcut displays now stay synchronized with configured shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->