### PR TITLE
fix(ci): Stop Sparkle from raising a modal alert during swift test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     name: Build and Test
     runs-on: macos-26
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/AnnotateTests/AboutViewTests.swift
+++ b/AnnotateTests/AboutViewTests.swift
@@ -84,8 +84,14 @@ final class AboutViewTests: XCTestCase {
             return
         }
 
-        // Verify we can start the updater (it shouldn't already be started)
-        XCTAssertNoThrow(try controller.startUpdater(), "Should be able to start updater since it wasn't started automatically")
+        // Never call `startUpdater()` here. Under xctest there is no app bundle with a feed
+        // URL or EdDSA key, so the start fails and Sparkle schedules a modal "Unable to Check
+        // For Updates" alert on the main queue four seconds later. On CI nobody can dismiss
+        // it, which wedged `swift test` for the full job limit. An unstarted updater reports
+        // that it cannot check for updates, which is the property this test cares about.
+        XCTAssertFalse(
+            controller.updater.canCheckForUpdates,
+            "Updater should not be started until startUpdater() is called explicitly")
     }
 
     // MARK: - View Body Tests


### PR DESCRIPTION
**Problem**

Every `pull_request` CI run since 2026-09-01 hung in `Swift Package Manager - Test` until the 6-hour job limit killed it: runs 33487706693, 33496631206, 33535003354, 33535265905, 33535433950, 33594067575, 33594903768, and 33718952447. All three open PRs (#75, #76, #78) were blocked on it. Push runs on `main` pass in 2 to 3 minutes.

The job had no `timeout-minutes`, and the log could not name the hung test: xctest's stdout is block-buffered into the runner pipe, and every hung log ended within 108 bytes of a 4096-byte boundary, so whatever test was mid-flight never made it out of the buffer.

**Cause**

`AboutViewTests.testUpdaterControllerIsNotStartedAutomatically` called `startUpdater()` on a real `SPUStandardUpdaterController`. Under xctest there is no app bundle with an `SUFeedURL` or EdDSA public key, so `SPUUpdater startUpdater:` fails every time, and `SPUStandardUpdaterController.startUpdater` (Sparkle 2.8.0) responds by scheduling a modal "Unable to Check For Updates" `NSAlert` on the main queue via `dispatch_after`, four seconds later.

The alert only fires if the process is still spinning its run loop when the block comes due. Locally the whole suite finishes in about 3 seconds, so the block never runs and the suite passes in both GUI and headless SSH sessions. CI runners are slower and were still inside `OverlayWindowTests` at the 4-second mark. Nobody can dismiss a modal on a runner, so the step sat there until the job limit.

The hangs began on 2026-09-01 because #72 and #73 added enough tests to push the CI suite past the 4-second fuse. Two of the eight runs in that window passed because they happened to finish under it.

Evidence: temporary instrumentation (a watchdog that sampled the `xctest` process at 7 minutes, not part of this PR) was pushed to this branch. On run 33728966860 (https://github.com/epilande/Annotate/actions/runs/33728966860) the sample shows the main thread inside `-[NSAlert runModal]`, called from Sparkle via a `dispatch_after` block on the main queue, underneath XCTest's own waiter.

**Fix**

- `AnnotateTests/AboutViewTests.swift`: stop calling `startUpdater()`. Assert on `controller.updater.canCheckForUpdates` instead, which is false until the updater is started and covers what the test cares about (the controller was created with `startingUpdater: false` and has not been started). A comment on the test explains why `startUpdater()` must not be called under xctest.
- `.github/workflows/ci.yml`: job-level `timeout-minutes: 20`, so a future hang fails in minutes instead of holding a runner for six hours.

**Verification**

- Local full `swift test`: 444 tests, 0 failures.
- A probe that spins the run loop for 6 seconds after `AboutViewTests` reproduces the hang with the old assertion (XCTest's stall detector aborts the process with signal 6) and passes cleanly with the new one. The probe is not part of this PR.
- CI on this PR is the final confirmation.
