### PR TITLE
feat(text): Keep text tool sticky by default after placing labels

### DIFF
--- a/Annotate/Constants.swift
+++ b/Annotate/Constants.swift
@@ -29,7 +29,10 @@ extension UserDefaults {
     static let spotlightRequiresOverlayKey = "SpotlightRequiresOverlay"
     static let activeCursorStyleKey = "ActiveCursorStyle"
     static let activeCursorSizeKey = "ActiveCursorSize"
+    /// Legacy key from v1.3.1. Left unused so its stored default is never flipped;
+    /// text stickiness now uses `returnToPreviousToolAfterTextKey`.
     static let persistTextModeKey = "PersistTextMode"
+    static let returnToPreviousToolAfterTextKey = "ReturnToPreviousToolAfterText"
     static let defaultTextFontSizeKey = "TextFontSize"
     static let textBackgroundKey = "TextBackgroundOn"
     static let defaultCounterFontSizeKey = "CounterFontSize"

--- a/Annotate/Constants.swift
+++ b/Annotate/Constants.swift
@@ -29,9 +29,6 @@ extension UserDefaults {
     static let spotlightRequiresOverlayKey = "SpotlightRequiresOverlay"
     static let activeCursorStyleKey = "ActiveCursorStyle"
     static let activeCursorSizeKey = "ActiveCursorSize"
-    /// Legacy key from v1.3.1. Left unused so its stored default is never flipped;
-    /// text stickiness now uses `returnToPreviousToolAfterTextKey`.
-    static let persistTextModeKey = "PersistTextMode"
     static let returnToPreviousToolAfterTextKey = "ReturnToPreviousToolAfterText"
     static let defaultTextFontSizeKey = "TextFontSize"
     static let textBackgroundKey = "TextBackgroundOn"

--- a/Annotate/GeneralSettingsView.swift
+++ b/Annotate/GeneralSettingsView.swift
@@ -14,8 +14,8 @@ struct GeneralSettingsView: View {
     private var soundsEnabled = UserDefaults.soundsEnabledDefault
     @AppStorage(UserDefaults.soundThemeKey)
     private var soundTheme: SoundTheme = UserDefaults.soundThemeDefault
-    @AppStorage(UserDefaults.persistTextModeKey)
-    private var persistTextMode = false
+    @AppStorage(UserDefaults.returnToPreviousToolAfterTextKey)
+    private var returnToPreviousToolAfterText = false
     @AppStorage(UserDefaults.defaultToolKey)
     private var defaultToolOption: DefaultToolOption = .lastUsed
 
@@ -106,9 +106,9 @@ struct GeneralSettingsView: View {
                     AppDelegate.shared?.updateDockIconVisibility()
                 }
 
-                Toggle(isOn: $persistTextMode) {
-                    Text("Persist Text Mode")
-                    Text("Stay in text mode after pressing Enter")
+                Toggle(isOn: $returnToPreviousToolAfterText) {
+                    Text("Return to previous tool after placing text")
+                    Text("After committing a label with Enter, switch back to the last tool")
                 }
 
                 Picker(selection: $defaultToolOption) {

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -1857,7 +1857,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
     }
 
     func restorePreviousTool() {
-        if UserDefaults.standard.bool(forKey: UserDefaults.persistTextModeKey) { return }
+        if !UserDefaults.standard.bool(forKey: UserDefaults.returnToPreviousToolAfterTextKey) { return }
 
         currentTool = previousTool
         AppDelegate.shared?.overlayWindows.values.forEach { window in
@@ -1931,7 +1931,6 @@ class OverlayView: NSView, NSTextFieldDelegate {
     {
         if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
             cancelTextAnnotation()
-            restorePreviousTool()
             return true
         } else if commandSelector == #selector(insertNewline(_:)) {
             guard let textField = control as? NSTextField else { return false }

--- a/AnnotateTests/AppDelegateTests.swift
+++ b/AnnotateTests/AppDelegateTests.swift
@@ -605,15 +605,16 @@ final class AppDelegateTests: XCTestCase, Sendable {
             return
         }
 
-        // restorePreviousTool reads persistTextMode from UserDefaults.standard, so pin it
-        // to false for this test and restore whatever was there afterwards.
-        let savedPersistTextMode = UserDefaults.standard.object(forKey: UserDefaults.persistTextModeKey)
-        UserDefaults.standard.set(false, forKey: UserDefaults.persistTextModeKey)
+        // restorePreviousTool reads the opt-in revert flag from UserDefaults.standard, so
+        // enable it for this test and restore whatever was there afterwards.
+        let savedRevertAfterText = UserDefaults.standard.object(
+            forKey: UserDefaults.returnToPreviousToolAfterTextKey)
+        UserDefaults.standard.set(true, forKey: UserDefaults.returnToPreviousToolAfterTextKey)
         defer {
-            if let saved = savedPersistTextMode {
-                UserDefaults.standard.set(saved, forKey: UserDefaults.persistTextModeKey)
+            if let saved = savedRevertAfterText {
+                UserDefaults.standard.set(saved, forKey: UserDefaults.returnToPreviousToolAfterTextKey)
             } else {
-                UserDefaults.standard.removeObject(forKey: UserDefaults.persistTextModeKey)
+                UserDefaults.standard.removeObject(forKey: UserDefaults.returnToPreviousToolAfterTextKey)
             }
         }
 

--- a/AnnotateTests/GeneralSettingsViewTests.swift
+++ b/AnnotateTests/GeneralSettingsViewTests.swift
@@ -245,23 +245,32 @@ final class GeneralSettingsViewTests: XCTestCase {
         )
     }
 
-    // MARK: - Persist Text Mode Toggle Tests
+    // MARK: - Return to Previous Tool After Text Toggle Tests
 
-    func testPersistTextModeToggleDefaultsToFalse() {
-        testDefaults.removeObject(forKey: UserDefaults.persistTextModeKey)
+    func testReturnToPreviousToolAfterTextDefaultsToFalse() {
+        testDefaults.removeObject(forKey: UserDefaults.returnToPreviousToolAfterTextKey)
 
-        let defaultValue = testDefaults.bool(forKey: UserDefaults.persistTextModeKey)
-        XCTAssertFalse(defaultValue, "persistTextMode should default to false")
+        let defaultValue = testDefaults.bool(forKey: UserDefaults.returnToPreviousToolAfterTextKey)
+        XCTAssertFalse(defaultValue, "returnToPreviousToolAfterText should default to false")
     }
 
-    func testPersistTextModeTogglePersistsValue() {
-        testDefaults.set(true, forKey: UserDefaults.persistTextModeKey)
-        let onValue = testDefaults.bool(forKey: UserDefaults.persistTextModeKey)
-        XCTAssertTrue(onValue, "persistTextMode should be true after setting to true")
+    func testReturnToPreviousToolAfterTextPersistsValue() {
+        testDefaults.set(true, forKey: UserDefaults.returnToPreviousToolAfterTextKey)
+        let onValue = testDefaults.bool(forKey: UserDefaults.returnToPreviousToolAfterTextKey)
+        XCTAssertTrue(onValue, "returnToPreviousToolAfterText should be true after setting to true")
 
-        testDefaults.set(false, forKey: UserDefaults.persistTextModeKey)
-        let offValue = testDefaults.bool(forKey: UserDefaults.persistTextModeKey)
-        XCTAssertFalse(offValue, "persistTextMode should be false after setting to false")
+        testDefaults.set(false, forKey: UserDefaults.returnToPreviousToolAfterTextKey)
+        let offValue = testDefaults.bool(forKey: UserDefaults.returnToPreviousToolAfterTextKey)
+        XCTAssertFalse(offValue, "returnToPreviousToolAfterText should be false after setting to false")
+    }
+
+    func testPersistTextModeDefaultIsUnchanged() {
+        testDefaults.removeObject(forKey: UserDefaults.persistTextModeKey)
+
+        XCTAssertFalse(
+            testDefaults.bool(forKey: UserDefaults.persistTextModeKey),
+            "PersistTextMode must keep its historical false default; do not flip it"
+        )
     }
 
     // MARK: - Edge Cases

--- a/AnnotateTests/GeneralSettingsViewTests.swift
+++ b/AnnotateTests/GeneralSettingsViewTests.swift
@@ -264,15 +264,6 @@ final class GeneralSettingsViewTests: XCTestCase {
         XCTAssertFalse(offValue, "returnToPreviousToolAfterText should be false after setting to false")
     }
 
-    func testPersistTextModeDefaultIsUnchanged() {
-        testDefaults.removeObject(forKey: UserDefaults.persistTextModeKey)
-
-        XCTAssertFalse(
-            testDefaults.bool(forKey: UserDefaults.persistTextModeKey),
-            "PersistTextMode must keep its historical false default; do not flip it"
-        )
-    }
-
     // MARK: - Edge Cases
 
     func testBoardOpacityAtBoundaries() {

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -934,4 +934,112 @@ final class OverlayViewTests: XCTestCase, Sendable {
             stamped, seeded,
             "A re-edited label restarts its fade clock instead of inheriting the old one")
     }
+
+    // MARK: - Text mode stickiness
+
+    func testEnterCommitsLabelAndStaysInTextModeByDefault() throws {
+        try withReturnToPreviousToolAfterText(nil) {
+            overlayView.currentTool = .text
+            overlayView.previousTool = .pen
+            overlayView.currentTextAnnotation = TextAnnotation(
+                text: "", position: NSPoint(x: 100, y: 100), color: .red,
+                fontSize: defaultTextAnnotationFontSize
+            )
+            overlayView.createTextField(at: NSPoint(x: 100, y: 100), withText: "", width: 100)
+            let textField = try XCTUnwrap(overlayView.activeTextField)
+            textField.stringValue = "Hello"
+
+            let handled = overlayView.control(
+                textField,
+                textView: NSTextView(),
+                doCommandBy: #selector(NSResponder.insertNewline(_:))
+            )
+
+            XCTAssertTrue(handled)
+            XCTAssertEqual(overlayView.currentTool, .text, "Enter should stay in text mode by default")
+            XCTAssertEqual(overlayView.textAnnotations.count, 1)
+            XCTAssertEqual(overlayView.textAnnotations[0].text, "Hello")
+            XCTAssertNil(overlayView.activeTextField)
+        }
+    }
+
+    func testEscapeCancelsFieldAndStaysInTextMode() throws {
+        try withReturnToPreviousToolAfterText(true) {
+            overlayView.currentTool = .text
+            overlayView.previousTool = .pen
+            overlayView.currentTextAnnotation = TextAnnotation(
+                text: "", position: NSPoint(x: 100, y: 100), color: .red,
+                fontSize: defaultTextAnnotationFontSize
+            )
+            overlayView.createTextField(at: NSPoint(x: 100, y: 100), withText: "", width: 100)
+            let textField = try XCTUnwrap(overlayView.activeTextField)
+            textField.stringValue = "Draft"
+
+            let handled = overlayView.control(
+                textField,
+                textView: NSTextView(),
+                doCommandBy: #selector(NSResponder.cancelOperation(_:))
+            )
+
+            XCTAssertTrue(handled)
+            XCTAssertEqual(
+                overlayView.currentTool, .text,
+                "Esc should stay in text mode even when revert after placing text is on"
+            )
+            XCTAssertTrue(overlayView.textAnnotations.isEmpty, "Esc should discard the uncommitted field")
+            XCTAssertNil(overlayView.activeTextField)
+        }
+    }
+
+    func testEnterRevertsToPreviousToolWhenOptedIn() throws {
+        try withReturnToPreviousToolAfterText(true) {
+            overlayView.currentTool = .text
+            overlayView.previousTool = .pen
+            overlayView.currentTextAnnotation = TextAnnotation(
+                text: "", position: NSPoint(x: 100, y: 100), color: .red,
+                fontSize: defaultTextAnnotationFontSize
+            )
+            overlayView.createTextField(at: NSPoint(x: 100, y: 100), withText: "", width: 100)
+            let textField = try XCTUnwrap(overlayView.activeTextField)
+            textField.stringValue = "Hello"
+
+            let handled = overlayView.control(
+                textField,
+                textView: NSTextView(),
+                doCommandBy: #selector(NSResponder.insertNewline(_:))
+            )
+
+            XCTAssertTrue(handled)
+            XCTAssertEqual(
+                overlayView.currentTool, .pen,
+                "Enter should restore the previous tool when revert after placing text is on"
+            )
+            XCTAssertEqual(overlayView.textAnnotations.count, 1)
+            XCTAssertEqual(overlayView.textAnnotations[0].text, "Hello")
+            XCTAssertNil(overlayView.activeTextField)
+        }
+    }
+
+    private func withReturnToPreviousToolAfterText(
+        _ enabled: Bool?,
+        body: () throws -> Void
+    ) rethrows {
+        let key = UserDefaults.returnToPreviousToolAfterTextKey
+        let saved = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let saved {
+                UserDefaults.standard.set(saved, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        if let enabled {
+            UserDefaults.standard.set(enabled, forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+
+        try body()
+    }
 }

--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ brew install --cask annotate
 | Custom (Settings)                                   | **Always-On Mode** | Persistent, non-interactive display  |
 | <kbd>Esc</kbd> or <kbd>Command</kbd> + <kbd>W</kbd> | **Close**          | Closes the annotation overlay        |
 | <kbd>Shift</kbd> + <kbd>Esc</kbd>                   | **Switch Mode**    | Close interactive → enable always-on |
-| <kbd>Enter</kbd> or <kbd>Esc</kbd> (in text)        | **Finalize Text**  | Complete text input                  |
+| <kbd>Enter</kbd> (in text)                          | **Commit Text**    | Place the label and stay in text mode |
+| <kbd>Esc</kbd> (in text)                            | **Cancel Text**    | Discard the in-progress label        |
 
 ### Drawing Tools
 
@@ -231,7 +232,7 @@ Annotate provides flexible line width control:
 #### Text Annotations
 
 - Click to place a text annotation
-- Type your text and press <kbd>Enter</kbd> or <kbd>Esc</kbd> to finalize
+- Type your text and press <kbd>Enter</kbd> to place it, or <kbd>Esc</kbd> to discard it
 - Double-click any text annotation to edit its content
 - Click and drag to reposition text
 - Press <kbd>Command</kbd> + <kbd>+</kbd> or <kbd>Command</kbd> + <kbd>-</kbd> while typing to resize the label

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Settings are organized into a sidebar with five panes: **General**, **Tools**, *
 - **Play sounds**: Play feedback sounds for overlay and clear actions.
 - **Sound Theme**: Choose between Chalk (default), Paper, Marker, Pencil, and Typewriter feedback sounds.
 - **Show in Dock**: Display Annotate icon in the Dock.
-- **Persist Text Mode**: Stay in text mode after pressing Enter.
+- **Return to previous tool after placing text**: After committing a label with Enter, switch back to the last tool. Off by default so text mode stays selected.
 - **Default Tool**: Choose which tool is selected each time the overlay is activated (defaults to last used).
 
 ### Tools


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Enter commits a label and stays in text mode
- Esc cancels the field and stays in text mode, regardless of settings
- Shift+Enter still commits and starts a new label below
- One-shot revert is opt-in as **Return to previous tool after placing text**, default off
- New `ReturnToPreviousToolAfterText` UserDefaults key so `PersistTextMode`'s default is not flipped. Users who already turned Persist Text Mode on keep sticky behavior; users who never touched it get sticky by default

## Testing
Tests added/updated for:
- Enter stays in text
- Esc stays in text even when revert is on
- Opt-in revert after placing text

This environment cannot run `xcodebuild` or the macOS test suite.

Closes #83

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60718966-a89d-42e4-aaca-8fc0e357d2ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60718966-a89d-42e4-aaca-8fc0e357d2ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to return to the previously selected tool after placing text; it is off by default.
  * Text mode now remains selected after committing text unless this option is enabled.
  * Pressing Escape cancels in-progress text and keeps text mode selected.

* **Documentation**
  * Clarified that Enter commits text while Escape cancels it.
  * Updated settings documentation for the new tool-return option.

* **Tests**
  * Added coverage for setting defaults, persistence, and text annotation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->