### PR TITLE
feat(sounds): Default Play sounds to off

### DIFF
--- a/Annotate/Constants.swift
+++ b/Annotate/Constants.swift
@@ -18,7 +18,7 @@ extension UserDefaults {
     static let toolbarVisibleKey = "ToolbarVisible"
     static let toolbarVisibleDefault = true
     static let soundsEnabledKey = "SoundsEnabled"
-    static let soundsEnabledDefault = true
+    static let soundsEnabledDefault = false
     static let soundThemeKey = "SoundTheme"
     static let soundThemeDefault = SoundTheme.chalk
     static let clickRippleEnabledKey = "ClickRippleEnabled"

--- a/AnnotateTests/GeneralSettingsViewTests.swift
+++ b/AnnotateTests/GeneralSettingsViewTests.swift
@@ -56,10 +56,10 @@ final class GeneralSettingsViewTests: XCTestCase {
         XCTAssertFalse(finalValue, "hideToolFeedback should be false after resetting")
     }
 
-    func testSoundsEnabledDefaultsToTrueWhenAbsent() {
+    func testSoundsEnabledDefaultsToFalseWhenAbsent() {
         testDefaults.removeObject(forKey: UserDefaults.soundsEnabledKey)
 
-        XCTAssertTrue(testDefaults.soundsEnabled)
+        XCTAssertFalse(testDefaults.soundsEnabled)
     }
 
     func testSoundsEnabledPersistsExplicitValue() {

--- a/AnnotateTests/SoundPlayerTests.swift
+++ b/AnnotateTests/SoundPlayerTests.swift
@@ -48,6 +48,7 @@ final class SoundPlayerTests: XCTestCase {
     }
 
     func testEachActionPlaysOnlyItsClip() {
+        testDefaults.soundsEnabled = true
         let players = makePlayers()
         let soundPlayer = SoundPlayer(userDefaults: testDefaults) { players[$0]?[$1] }
         let chalk = players[.chalk]
@@ -66,6 +67,19 @@ final class SoundPlayerTests: XCTestCase {
         XCTAssertEqual(chalk?[.overlayOn]?.playCount, 1)
         XCTAssertEqual(chalk?[.overlayOff]?.playCount, 1)
         XCTAssertEqual(chalk?[.clearAll]?.playCount, 1)
+    }
+
+    func testPlaybackIsSilentWhenSoundsEnabledKeyIsAbsent() {
+        testDefaults.removeObject(forKey: UserDefaults.soundsEnabledKey)
+        let players = makePlayers()
+        let soundPlayer = SoundPlayer(userDefaults: testDefaults) { players[$0]?[$1] }
+        let chalk = players[.chalk] ?? [:]
+
+        soundPlayer.playOverlayOn()
+        soundPlayer.playOverlayOff()
+        soundPlayer.playClearAll()
+
+        XCTAssertTrue(chalk.values.allSatisfy { $0.playCount == 0 })
     }
 
     func testPlaybackFollowsSoundsEnabledSetting() {
@@ -89,6 +103,7 @@ final class SoundPlayerTests: XCTestCase {
     }
 
     func testPlaybackUsesSelectedTheme() {
+        testDefaults.soundsEnabled = true
         let players = makePlayers()
         let soundPlayer = SoundPlayer(userDefaults: testDefaults) { players[$0]?[$1] }
 
@@ -106,6 +121,7 @@ final class SoundPlayerTests: XCTestCase {
     }
 
     func testPlaybackRestartsLoadedClip() {
+        testDefaults.soundsEnabled = true
         let players = makePlayers()
         players[.chalk]?[.overlayOn]?.currentTime = 1
         let soundPlayer = SoundPlayer(userDefaults: testDefaults) { players[$0]?[$1] }

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Settings are organized into a sidebar with five panes: **General**, **Tools**, *
 - **Clear Drawings on Toggle**: Automatically clear all drawings when toggling the overlay off.
 - **Hide Tool Feedback**: Disable visual feedback when switching tools.
 - **Show toolbar**: Display the floating shortcut toolbar on annotation overlays.
-- **Play sounds**: Play feedback sounds for overlay and clear actions.
+- **Play sounds**: Play feedback sounds for overlay and clear actions. Off by default.
 - **Sound Theme**: Choose between Chalk (default), Paper, Marker, Pencil, and Typewriter feedback sounds.
 - **Show in Dock**: Display Annotate icon in the Dock.
 - **Return to previous tool after placing text**: After committing a label with Enter, switch back to the last tool. Off by default so text mode stays selected.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Treat an absent `SoundsEnabled` key as **off**, so new installs and untouched preferences stay silent
- Users who already turned **Play sounds** on keep sounds on; users who turned it off stay off
- Settings label stays **Play sounds**; README now documents the opt-in default
- Flipped `soundsEnabledDefault` on the existing key (no migration key). Absence already has an explicit getter, so this does not invert a stored preference

## Testing
Updated `GeneralSettingsViewTests` and `SoundPlayerTests` so absence is silent and playback tests opt in explicitly.

This environment cannot run `xcodebuild` or the macOS test suite.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12850aa9-013f-4342-927f-0da4ce5293bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12850aa9-013f-4342-927f-0da4ce5293bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - Sound effects are now disabled by default when no preference has been saved.
  - Users can still enable sounds through the “Play sounds” setting.

- **Documentation**
  - Updated the General settings documentation to clarify that sound effects are off by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->