### PR TITLE
feat(text): Switch to Select after placing a label and commit on Esc

### DIFF
--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -575,11 +575,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuItem
     /// setting is "Last used", leaving whatever tool is already current in place, or when
     /// every window is already on the configured tool (avoids showing tool feedback on
     /// every activation). Applying the default is not an explicit tool selection, so it does
-    /// not overwrite the persisted last-used tool.
+    /// not overwrite the persisted last-used tool — even if a toolbar sync re-enters
+    /// `switchTool` with the default `persist: true`.
     func applyConfiguredDefaultTool() {
         guard case .tool(let tool) = userDefaults.defaultToolOption else { return }
         guard overlayWindows.values.contains(where: { $0.overlayView.currentTool != tool }) else { return }
+
+        let preservedLastUsed = userDefaults.string(forKey: UserDefaults.lastUsedToolKey)
         switchTool(to: tool, persist: false)
+        if let preservedLastUsed {
+            userDefaults.set(preservedLastUsed, forKey: UserDefaults.lastUsedToolKey)
+        } else {
+            userDefaults.removeObject(forKey: UserDefaults.lastUsedToolKey)
+        }
     }
 
     @objc func enableArrowMode(_ sender: NSMenuItem) {

--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -562,10 +562,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuItem
                 window.overlayView.selectedObjects.removeAll()
                 window.overlayView.needsDisplay = true
             }
-            // Save current tool as previous when switching TO text mode
-            if tool == .text && window.overlayView.currentTool != .text {
-                window.overlayView.previousTool = window.overlayView.currentTool
-            }
             window.overlayView.currentTool = tool
             window.showToolFeedback(tool)
             window.invalidateCursorRects(for: window.overlayView)

--- a/Annotate/AppDelegate.swift
+++ b/Annotate/AppDelegate.swift
@@ -575,19 +575,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuItem
     /// setting is "Last used", leaving whatever tool is already current in place, or when
     /// every window is already on the configured tool (avoids showing tool feedback on
     /// every activation). Applying the default is not an explicit tool selection, so it does
-    /// not overwrite the persisted last-used tool — even if a toolbar sync re-enters
-    /// `switchTool` with the default `persist: true`.
+    /// not overwrite the persisted last-used tool.
     func applyConfiguredDefaultTool() {
         guard case .tool(let tool) = userDefaults.defaultToolOption else { return }
         guard overlayWindows.values.contains(where: { $0.overlayView.currentTool != tool }) else { return }
-
-        let preservedLastUsed = userDefaults.string(forKey: UserDefaults.lastUsedToolKey)
         switchTool(to: tool, persist: false)
-        if let preservedLastUsed {
-            userDefaults.set(preservedLastUsed, forKey: UserDefaults.lastUsedToolKey)
-        } else {
-            userDefaults.removeObject(forKey: UserDefaults.lastUsedToolKey)
-        }
     }
 
     @objc func enableArrowMode(_ sender: NSMenuItem) {

--- a/Annotate/Constants.swift
+++ b/Annotate/Constants.swift
@@ -29,7 +29,7 @@ extension UserDefaults {
     static let spotlightRequiresOverlayKey = "SpotlightRequiresOverlay"
     static let activeCursorStyleKey = "ActiveCursorStyle"
     static let activeCursorSizeKey = "ActiveCursorSize"
-    static let returnToPreviousToolAfterTextKey = "ReturnToPreviousToolAfterText"
+    static let selectAfterPlacingTextKey = "SelectAfterPlacingText"
     static let defaultTextFontSizeKey = "TextFontSize"
     static let textBackgroundKey = "TextBackgroundOn"
     static let defaultCounterFontSizeKey = "CounterFontSize"
@@ -94,6 +94,13 @@ extension UserDefaults {
     var textBackgroundEnabled: Bool {
         get { bool(forKey: Self.textBackgroundKey) }
         set { set(newValue, forKey: Self.textBackgroundKey) }
+    }
+
+    /// Whether committing a label switches to the Select tool with that label selected.
+    /// Off by default so text mode stays sticky.
+    var selectAfterPlacingText: Bool {
+        get { bool(forKey: Self.selectAfterPlacingTextKey) }
+        set { set(newValue, forKey: Self.selectAfterPlacingTextKey) }
     }
 
     var counterToolFontSize: CGFloat {

--- a/Annotate/GeneralSettingsView.swift
+++ b/Annotate/GeneralSettingsView.swift
@@ -14,8 +14,8 @@ struct GeneralSettingsView: View {
     private var soundsEnabled = UserDefaults.soundsEnabledDefault
     @AppStorage(UserDefaults.soundThemeKey)
     private var soundTheme: SoundTheme = UserDefaults.soundThemeDefault
-    @AppStorage(UserDefaults.returnToPreviousToolAfterTextKey)
-    private var returnToPreviousToolAfterText = false
+    @AppStorage(UserDefaults.selectAfterPlacingTextKey)
+    private var selectAfterPlacingText = false
     @AppStorage(UserDefaults.defaultToolKey)
     private var defaultToolOption: DefaultToolOption = .lastUsed
 
@@ -106,9 +106,9 @@ struct GeneralSettingsView: View {
                     AppDelegate.shared?.updateDockIconVisibility()
                 }
 
-                Toggle(isOn: $returnToPreviousToolAfterText) {
-                    Text("Return to previous tool after placing text")
-                    Text("After committing a label with Enter, switch back to the last tool")
+                Toggle(isOn: $selectAfterPlacingText) {
+                    Text("Switch to Select after placing text")
+                    Text("After committing a label, select it so you can move it right away")
                 }
 
                 Picker(selection: $defaultToolOption) {

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -100,6 +100,10 @@ class OverlayView: NSView, NSTextFieldDelegate {
     var dragOffset: NSPoint?
     var editingTextAnnotationIndex: Int?
 
+    /// Index of the label written by the last `finalizeTextAnnotation` call, or nil when that
+    /// call committed nothing. Lets `commitTextField` select what the user just placed.
+    private(set) var lastCommittedTextIndex: Int?
+
     var counterAnnotations: [CounterAnnotation] = []
     var nextCounterNumber: Int = 1
 
@@ -122,7 +126,6 @@ class OverlayView: NSView, NSTextFieldDelegate {
     var currentTool: ToolType = .pen {
         didSet { notifyToolbarChanged() }
     }
-    var previousTool: ToolType = .pen
     var currentLineWidth: CGFloat = 3.0 {
         didSet { notifyToolbarChanged() }
     }
@@ -1783,7 +1786,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
         textField.cell = PaddedTextFieldCell()
         textField.onCommandReturn = { [weak self, weak textField] in
             guard let self = self, let textField = textField else { return }
-            self.finalizeTextAnnotation(textField)
+            self.commitTextField(textField)
         }
         textField.onFontSizeStep = { [weak self] direction in
             (self?.window as? OverlayWindow)?.stepTextFontSize(direction)
@@ -1856,19 +1859,33 @@ class OverlayView: NSView, NSTextFieldDelegate {
         needsDisplay = true
     }
 
-    func restorePreviousTool() {
-        if !UserDefaults.standard.bool(forKey: UserDefaults.returnToPreviousToolAfterTextKey) { return }
+    /// Commits the field, then honors the opt-in switch to Select so the label the user
+    /// just placed can be moved right away.
+    ///
+    /// The tool switch runs the per-window loop by hand instead of going through
+    /// `AppDelegate.switchTool(to:)`: that call toggles always-on mode, flashes the tool
+    /// feedback HUD, and persists the choice as the last used tool, none of which should
+    /// happen for an internal switch the user did not ask for.
+    func commitTextField(_ textField: NSTextField) {
+        finalizeTextAnnotation(textField)
 
-        currentTool = previousTool
+        guard pickerUserDefaults.selectAfterPlacingText,
+              let committedIndex = lastCommittedTextIndex else { return }
+
+        currentTool = .select
         AppDelegate.shared?.overlayWindows.values.forEach { window in
-            window.overlayView.currentTool = previousTool
+            window.overlayView.currentTool = .select
             window.invalidateCursorRects(for: window.overlayView)
             window.overlayView.updateCursor()
         }
-        AppDelegate.shared?.updateCurrentToolMenuItem(to: previousTool.displayName)
+        AppDelegate.shared?.updateCurrentToolMenuItem(to: ToolType.select.displayName)
+
+        selectedObjects = [.text(index: committedIndex)]
+        needsDisplay = true
     }
 
     @objc func finalizeTextAnnotation(_ sender: NSTextField) {
+        lastCommittedTextIndex = nil
         let typedText = sender.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
         // Account for PaddedTextFieldCell padding when storing position
         let position = NSPoint(
@@ -1904,11 +1921,13 @@ class OverlayView: NSView, NSTextFieldDelegate {
                     registerUndo(action: .removeText(textAnnotations[editingIndex]))
                     textAnnotations[editingIndex] = finalAnnotation
                     registerUndo(action: .addText(finalAnnotation))
+                    lastCommittedTextIndex = editingIndex
                 }
                 editingTextAnnotationIndex = nil
             } else {
                 registerUndo(action: .addText(finalAnnotation))
                 textAnnotations.append(finalAnnotation)
+                lastCommittedTextIndex = textAnnotations.count - 1
             }
             if fadeMode {
                 (window as? OverlayWindow)?.startFadeLoop()
@@ -1930,7 +1949,19 @@ class OverlayView: NSView, NSTextFieldDelegate {
         -> Bool
     {
         if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
-            cancelTextAnnotation()
+            guard let textField = control as? NSTextField else {
+                cancelTextAnnotation()
+                return true
+            }
+
+            // Esc mirrors Enter for a field with text so a label is never lost by reflex,
+            // and still discards an empty field without leaving text mode.
+            let hasText = !textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            if hasText {
+                commitTextField(textField)
+            } else {
+                cancelTextAnnotation()
+            }
             return true
         } else if commandSelector == #selector(insertNewline(_:)) {
             guard let textField = control as? NSTextField else { return false }
@@ -1943,8 +1974,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
                 createTextFieldForNewAnnotation(at: NSPoint(x: position.x, y: newY))
                 return true
             } else {
-                finalizeTextAnnotation(textField)
-                restorePreviousTool()
+                commitTextField(textField)
                 return true
             }
         }

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -236,13 +236,24 @@ class OverlayView: NSView, NSTextFieldDelegate {
     }
 
     func undo() {
+        // An undone object leaves its index behind in the selection, which would draw a
+        // selection box over an object that is no longer there.
+        clearSelectionForHistoryStep()
         undoManager?.undo()
         startFadeLoopIfNeeded()
     }
 
     func redo() {
+        clearSelectionForHistoryStep()
         undoManager?.redo()
         startFadeLoopIfNeeded()
+    }
+
+    /// Drops the selection before an undo or redo reshuffles the annotation arrays.
+    private func clearSelectionForHistoryStep() {
+        guard !selectedObjects.isEmpty else { return }
+        selectedObjects.removeAll()
+        needsDisplay = true
     }
 
     func startFadeLoopIfNeeded() {
@@ -1819,7 +1830,7 @@ class OverlayView: NSView, NSTextFieldDelegate {
         textField.stringValue = existingText
         textField.target = self
         textField.delegate = self
-        textField.action = #selector(finalizeTextAnnotation(_:))
+        textField.action = #selector(commitTextField(_:))
 
         textField.wantsLayer = true
         textField.layer?.cornerRadius = 6
@@ -1869,13 +1880,20 @@ class OverlayView: NSView, NSTextFieldDelegate {
     /// `AppDelegate.switchTool(to:)`: that call toggles always-on mode, flashes the tool
     /// feedback HUD, and persists the choice as the last used tool, none of which should
     /// happen for an internal switch the user did not ask for.
-    func commitTextField(_ textField: NSTextField) {
+    ///
+    /// Only the gestures that mean "place this label" come through here: Enter, Cmd+Enter,
+    /// Esc on a field with text, and clicking away on the canvas. The other paths stay on
+    /// `finalizeTextAnnotation` on purpose, because none of them is the user finishing a
+    /// label: losing focus (`controlTextDidEndEditing`), pressing a toolbar button
+    /// (`OverlayWindow.performToolbarAction`), closing the overlay or flipping always-on
+    /// mode (`AppDelegate`), Shift+Enter chaining straight into the next label, and
+    /// `createTextField` closing whatever field is still open before it opens a new one.
+    @objc func commitTextField(_ textField: NSTextField) {
         finalizeTextAnnotation(textField)
 
         guard pickerUserDefaults.selectAfterPlacingText,
               let committedIndex = lastCommittedTextIndex else { return }
 
-        currentTool = .select
         // Only broadcast to the live overlay set when this view is one of those
         // windows. A detached view (unit tests, previews) must not rewrite
         // another suite's current tool or last-used menu.
@@ -1888,6 +1906,8 @@ class OverlayView: NSView, NSTextFieldDelegate {
                 window.overlayView.updateCursor()
             }
             appDelegate.updateCurrentToolMenuItem(to: ToolType.select.displayName)
+        } else {
+            currentTool = .select
         }
 
         selectedObjects = [.text(index: committedIndex)]

--- a/Annotate/OverlayView.swift
+++ b/Annotate/OverlayView.swift
@@ -135,10 +135,13 @@ class OverlayView: NSView, NSTextFieldDelegate {
     }
     let fadeDuration: CFTimeInterval = 1.25
 
+    /// Test hook. Production always resolves through `AppDelegate.shared` or `.standard`.
+    var pickerUserDefaultsOverride: UserDefaults?
+
     /// Mirrors `OverlayWindow.pickerUserDefaults` so the view and the window resolve tool
     /// defaults through the same store.
     var pickerUserDefaults: UserDefaults {
-        AppDelegate.shared?.userDefaults ?? .standard
+        pickerUserDefaultsOverride ?? AppDelegate.shared?.userDefaults ?? .standard
     }
     var isReadOnlyMode: Bool = false
 
@@ -1873,12 +1876,19 @@ class OverlayView: NSView, NSTextFieldDelegate {
               let committedIndex = lastCommittedTextIndex else { return }
 
         currentTool = .select
-        AppDelegate.shared?.overlayWindows.values.forEach { window in
-            window.overlayView.currentTool = .select
-            window.invalidateCursorRects(for: window.overlayView)
-            window.overlayView.updateCursor()
+        // Only broadcast to the live overlay set when this view is one of those
+        // windows. A detached view (unit tests, previews) must not rewrite
+        // another suite's current tool or last-used menu.
+        if let appDelegate = AppDelegate.shared,
+            appDelegate.overlayWindows.values.contains(where: { $0.overlayView === self })
+        {
+            appDelegate.overlayWindows.values.forEach { window in
+                window.overlayView.currentTool = .select
+                window.invalidateCursorRects(for: window.overlayView)
+                window.overlayView.updateCursor()
+            }
+            appDelegate.updateCurrentToolMenuItem(to: ToolType.select.displayName)
         }
-        AppDelegate.shared?.updateCurrentToolMenuItem(to: ToolType.select.displayName)
 
         selectedObjects = [.text(index: committedIndex)]
         needsDisplay = true

--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -905,7 +905,14 @@ class OverlayWindow: NSPanel {
         let shiftPressed = event.modifierFlags.contains(.shift)
 
         if let activeTextField = overlayView.activeTextField {
-            overlayView.finalizeTextAnnotation(activeTextField)
+            // Clicking away is how most labels get placed, so it commits through the same
+            // path as Enter and Esc. When that switches the tool, this click has already
+            // done its job and must not also start a gesture with the new tool.
+            let toolBeforeCommit = overlayView.currentTool
+            overlayView.commitTextField(activeTextField)
+            if overlayView.currentTool != toolBeforeCommit {
+                return
+            }
         }
         
         // Handle selection mode

--- a/AnnotateTests/AppDelegateTests.swift
+++ b/AnnotateTests/AppDelegateTests.swift
@@ -457,39 +457,6 @@ final class AppDelegateTests: XCTestCase, Sendable {
         CursorHighlightManager.shared = CursorHighlightManager()
     }
 
-    // MARK: - Previous Tool Tracking Tests
-
-    func testSwitchToolSavesPreviousToolForTextMode() {
-        guard let overlayWindow = appDelegate.overlayWindows.values.first else {
-            XCTFail("No overlay window available")
-            return
-        }
-
-        appDelegate.enableArrowMode(NSMenuItem())
-        XCTAssertEqual(overlayWindow.overlayView.currentTool, .arrow)
-
-        appDelegate.enableTextMode(NSMenuItem())
-
-        XCTAssertEqual(overlayWindow.overlayView.currentTool, .text)
-        XCTAssertEqual(overlayWindow.overlayView.previousTool, .arrow, "previousTool should be .arrow after switching from arrow to text")
-    }
-
-    func testSwitchToolDoesNotSavePreviousToolForOtherModes() {
-        guard let overlayWindow = appDelegate.overlayWindows.values.first else {
-            XCTFail("No overlay window available")
-            return
-        }
-
-        overlayWindow.overlayView.previousTool = .pen
-        appDelegate.enableArrowMode(NSMenuItem())
-
-        let previousToolBefore = overlayWindow.overlayView.previousTool
-        appDelegate.enableLineMode(NSMenuItem())
-
-        XCTAssertEqual(overlayWindow.overlayView.currentTool, .line)
-        XCTAssertEqual(overlayWindow.overlayView.previousTool, previousToolBefore, "previousTool should remain unchanged when not switching to text mode")
-    }
-
     // MARK: - Default Tool Tests
 
     func testSwitchToolPersistsLastUsedTool() {
@@ -599,34 +566,31 @@ final class AppDelegateTests: XCTestCase, Sendable {
         }
     }
 
-    func testInternalToolRestoreDoesNotOverwriteLastUsedTool() {
+    func testInternalToolSwitchDoesNotOverwriteLastUsedTool() throws {
         guard let overlayWindow = appDelegate.overlayWindows.values.first else {
             XCTFail("No overlay window available")
             return
         }
 
-        // restorePreviousTool reads the opt-in revert flag from UserDefaults.standard, so
-        // enable it for this test and restore whatever was there afterwards.
-        let savedRevertAfterText = UserDefaults.standard.object(
-            forKey: UserDefaults.returnToPreviousToolAfterTextKey)
-        UserDefaults.standard.set(true, forKey: UserDefaults.returnToPreviousToolAfterTextKey)
-        defer {
-            if let saved = savedRevertAfterText {
-                UserDefaults.standard.set(saved, forKey: UserDefaults.returnToPreviousToolAfterTextKey)
-            } else {
-                UserDefaults.standard.removeObject(forKey: UserDefaults.returnToPreviousToolAfterTextKey)
-            }
-        }
+        appDelegate.userDefaults.selectAfterPlacingText = true
 
         appDelegate.enablePenMode(NSMenuItem())
         appDelegate.enableTextMode(NSMenuItem())
         XCTAssertEqual(testDefaults.lastUsedTool, .text, "Explicitly switching to text should persist it as last used")
-        XCTAssertEqual(overlayWindow.overlayView.previousTool, .pen)
 
-        overlayWindow.overlayView.restorePreviousTool()
+        let overlayView: OverlayView = try XCTUnwrap(overlayWindow.overlayView)
+        let point = NSPoint(x: 100, y: 100)
+        overlayView.currentTextAnnotation = TextAnnotation(
+            text: "", position: point, color: .red,
+            fontSize: defaultTextAnnotationFontSize
+        )
+        overlayView.createTextField(at: point, withText: "", width: 100)
+        let textField = try XCTUnwrap(overlayView.activeTextField)
+        textField.stringValue = "Hello"
+        overlayView.commitTextField(textField)
 
-        XCTAssertEqual(overlayWindow.overlayView.currentTool, .pen, "Finishing a text annotation should restore the previous tool")
-        XCTAssertEqual(testDefaults.lastUsedTool, .text, "Internal tool restores should not overwrite the persisted last-used tool")
+        XCTAssertEqual(overlayView.currentTool, .select, "Committing a label should switch to Select")
+        XCTAssertEqual(testDefaults.lastUsedTool, .text, "Internal tool switches should not overwrite the persisted last-used tool")
     }
 }
 

--- a/AnnotateTests/BoardViewTests.swift
+++ b/AnnotateTests/BoardViewTests.swift
@@ -5,10 +5,15 @@ import XCTest
 @MainActor
 final class BoardViewTests: XCTestCase, Sendable {
     var boardView: BoardView!
+    var testDefaults: UserDefaults!
 
     nonisolated override func setUp() {
         super.setUp()
         MainActor.assumeIsolated {
+            // Unique suite so leftover BoardOpacity from other classes
+            // (or a prior 0.5 write on .standard) cannot make both colors identical.
+            testDefaults = TestUserDefaults.create()
+            BoardManager.shared = BoardManager(userDefaults: testDefaults)
             boardView = BoardView(frame: NSRect(x: 0, y: 0, width: 500, height: 500))
         }
     }
@@ -16,7 +21,9 @@ final class BoardViewTests: XCTestCase, Sendable {
     nonisolated override func tearDown() {
         MainActor.assumeIsolated {
             boardView = nil
+            BoardManager.shared = BoardManager()
         }
+        TestUserDefaults.removeSuite()
         super.tearDown()
     }
 
@@ -27,20 +34,20 @@ final class BoardViewTests: XCTestCase, Sendable {
     }
 
     func testBoardBackgroundColor() {
-        let backgroundColor = boardView.layer?.backgroundColor
+        // Pin a known start opacity. Shared BoardManager state from other
+        // suites can already be 0.5, which would make the next write a no-op.
+        BoardManager.shared.opacity = 0.9
+        boardView.updateForAppearance()
 
+        let backgroundColor = boardView.layer?.backgroundColor
         XCTAssertNotNil(backgroundColor, "Background color should be set")
 
-        let originalOpacity = BoardManager.shared.opacity
         BoardManager.shared.opacity = 0.5
-
         boardView.updateForAppearance()
 
         let newBackgroundColor = boardView.layer?.backgroundColor
         XCTAssertNotEqual(
             backgroundColor, newBackgroundColor, "Background color should change with opacity")
-
-        BoardManager.shared.opacity = originalOpacity
     }
 
     func testVisibilityChangeNotification() {

--- a/AnnotateTests/GeneralSettingsViewTests.swift
+++ b/AnnotateTests/GeneralSettingsViewTests.swift
@@ -245,23 +245,20 @@ final class GeneralSettingsViewTests: XCTestCase {
         )
     }
 
-    // MARK: - Return to Previous Tool After Text Toggle Tests
+    // MARK: - Select After Placing Text Toggle Tests
 
-    func testReturnToPreviousToolAfterTextDefaultsToFalse() {
-        testDefaults.removeObject(forKey: UserDefaults.returnToPreviousToolAfterTextKey)
+    func testSelectAfterPlacingTextDefaultsToFalse() {
+        testDefaults.removeObject(forKey: UserDefaults.selectAfterPlacingTextKey)
 
-        let defaultValue = testDefaults.bool(forKey: UserDefaults.returnToPreviousToolAfterTextKey)
-        XCTAssertFalse(defaultValue, "returnToPreviousToolAfterText should default to false")
+        XCTAssertFalse(testDefaults.selectAfterPlacingText, "selectAfterPlacingText should default to false")
     }
 
-    func testReturnToPreviousToolAfterTextPersistsValue() {
-        testDefaults.set(true, forKey: UserDefaults.returnToPreviousToolAfterTextKey)
-        let onValue = testDefaults.bool(forKey: UserDefaults.returnToPreviousToolAfterTextKey)
-        XCTAssertTrue(onValue, "returnToPreviousToolAfterText should be true after setting to true")
+    func testSelectAfterPlacingTextPersistsValue() {
+        testDefaults.selectAfterPlacingText = true
+        XCTAssertTrue(testDefaults.selectAfterPlacingText, "selectAfterPlacingText should be true after setting to true")
 
-        testDefaults.set(false, forKey: UserDefaults.returnToPreviousToolAfterTextKey)
-        let offValue = testDefaults.bool(forKey: UserDefaults.returnToPreviousToolAfterTextKey)
-        XCTAssertFalse(offValue, "returnToPreviousToolAfterText should be false after setting to false")
+        testDefaults.selectAfterPlacingText = false
+        XCTAssertFalse(testDefaults.selectAfterPlacingText, "selectAfterPlacingText should be false after setting to false")
     }
 
     // MARK: - Edge Cases

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -9,12 +9,17 @@ final class OverlayViewTests: XCTestCase, Sendable {
     nonisolated override func setUp() {
         super.setUp()
         MainActor.assumeIsolated {
+            // A leaked AppDelegate.shared would redirect pickerUserDefaults into
+            // another suite's store and let commitTextField rewrite its windows.
+            AppDelegate.shared = nil
             overlayView = OverlayView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+            overlayView.pickerUserDefaultsOverride = TestUserDefaults.create()
         }
     }
 
     nonisolated override func tearDown() {
         MainActor.assumeIsolated {
+            overlayView?.pickerUserDefaultsOverride = nil
             overlayView = nil
         }
         super.tearDown()

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -938,16 +938,10 @@ final class OverlayViewTests: XCTestCase, Sendable {
     // MARK: - Text mode stickiness
 
     func testEnterCommitsLabelAndStaysInTextModeByDefault() throws {
-        try withReturnToPreviousToolAfterText(nil) {
+        try withSelectAfterPlacingText(nil) {
             overlayView.currentTool = .text
-            overlayView.previousTool = .pen
-            overlayView.currentTextAnnotation = TextAnnotation(
-                text: "", position: NSPoint(x: 100, y: 100), color: .red,
-                fontSize: defaultTextAnnotationFontSize
-            )
-            overlayView.createTextField(at: NSPoint(x: 100, y: 100), withText: "", width: 100)
+            seedNewTextField(text: "Hello")
             let textField = try XCTUnwrap(overlayView.activeTextField)
-            textField.stringValue = "Hello"
 
             let handled = overlayView.control(
                 textField,
@@ -963,17 +957,80 @@ final class OverlayViewTests: XCTestCase, Sendable {
         }
     }
 
-    func testEscapeCancelsFieldAndStaysInTextMode() throws {
-        try withReturnToPreviousToolAfterText(true) {
+    func testEnterSelectsThePlacedLabelWhenOptedIn() throws {
+        try withSelectAfterPlacingText(true) {
             overlayView.currentTool = .text
-            overlayView.previousTool = .pen
-            overlayView.currentTextAnnotation = TextAnnotation(
-                text: "", position: NSPoint(x: 100, y: 100), color: .red,
-                fontSize: defaultTextAnnotationFontSize
-            )
-            overlayView.createTextField(at: NSPoint(x: 100, y: 100), withText: "", width: 100)
+            seedNewTextField(text: "Hello")
             let textField = try XCTUnwrap(overlayView.activeTextField)
-            textField.stringValue = "Draft"
+
+            let handled = overlayView.control(
+                textField,
+                textView: NSTextView(),
+                doCommandBy: #selector(NSResponder.insertNewline(_:))
+            )
+
+            XCTAssertTrue(handled)
+            XCTAssertEqual(
+                overlayView.currentTool, .select,
+                "Enter should switch to Select when select after placing text is on"
+            )
+            XCTAssertEqual(overlayView.textAnnotations.count, 1)
+            XCTAssertEqual(
+                overlayView.selectedObjects, [.text(index: 0)],
+                "The label that was just placed should be the selection"
+            )
+            XCTAssertNil(overlayView.activeTextField)
+        }
+    }
+
+    func testEscapeCommitsLabelAndStaysInTextModeByDefault() throws {
+        try withSelectAfterPlacingText(nil) {
+            overlayView.currentTool = .text
+            seedNewTextField(text: "Draft")
+            let textField = try XCTUnwrap(overlayView.activeTextField)
+
+            let handled = overlayView.control(
+                textField,
+                textView: NSTextView(),
+                doCommandBy: #selector(NSResponder.cancelOperation(_:))
+            )
+
+            XCTAssertTrue(handled)
+            XCTAssertEqual(overlayView.currentTool, .text, "Esc should stay in text mode by default")
+            XCTAssertEqual(overlayView.textAnnotations.count, 1)
+            XCTAssertEqual(
+                overlayView.textAnnotations[0].text, "Draft",
+                "Esc on a field with text should place the label instead of discarding it"
+            )
+            XCTAssertNil(overlayView.activeTextField)
+        }
+    }
+
+    func testEscapeSelectsThePlacedLabelWhenOptedIn() throws {
+        try withSelectAfterPlacingText(true) {
+            overlayView.currentTool = .text
+            seedNewTextField(text: "Draft")
+            let textField = try XCTUnwrap(overlayView.activeTextField)
+
+            let handled = overlayView.control(
+                textField,
+                textView: NSTextView(),
+                doCommandBy: #selector(NSResponder.cancelOperation(_:))
+            )
+
+            XCTAssertTrue(handled)
+            XCTAssertEqual(overlayView.currentTool, .select, "Esc commits like Enter, including the switch")
+            XCTAssertEqual(overlayView.textAnnotations.count, 1)
+            XCTAssertEqual(overlayView.selectedObjects, [.text(index: 0)])
+            XCTAssertNil(overlayView.activeTextField)
+        }
+    }
+
+    func testEscapeOnEmptyFieldDiscardsItAndStaysInTextMode() throws {
+        try withSelectAfterPlacingText(true) {
+            overlayView.currentTool = .text
+            seedNewTextField(text: "")
+            let textField = try XCTUnwrap(overlayView.activeTextField)
 
             let handled = overlayView.control(
                 textField,
@@ -984,60 +1041,72 @@ final class OverlayViewTests: XCTestCase, Sendable {
             XCTAssertTrue(handled)
             XCTAssertEqual(
                 overlayView.currentTool, .text,
-                "Esc should stay in text mode even when revert after placing text is on"
+                "An empty field is a cancel, so it never switches tools"
             )
-            XCTAssertTrue(overlayView.textAnnotations.isEmpty, "Esc should discard the uncommitted field")
+            XCTAssertTrue(overlayView.textAnnotations.isEmpty)
             XCTAssertNil(overlayView.activeTextField)
         }
     }
 
-    func testEnterRevertsToPreviousToolWhenOptedIn() throws {
-        try withReturnToPreviousToolAfterText(true) {
+    func testEscapeOnClearedEditKeepsTheOriginalLabel() throws {
+        try withSelectAfterPlacingText(true) {
             overlayView.currentTool = .text
-            overlayView.previousTool = .pen
-            overlayView.currentTextAnnotation = TextAnnotation(
-                text: "", position: NSPoint(x: 100, y: 100), color: .red,
+            let original = TextAnnotation(
+                text: "Hi", position: NSPoint(x: 100, y: 100), color: .red,
                 fontSize: defaultTextAnnotationFontSize
             )
-            overlayView.createTextField(at: NSPoint(x: 100, y: 100), withText: "", width: 100)
+            overlayView.textAnnotations = [original]
+            overlayView.editingTextAnnotationIndex = 0
+            overlayView.currentTextAnnotation = original
+            overlayView.createTextField(at: original.position, withText: original.text, width: 300)
             let textField = try XCTUnwrap(overlayView.activeTextField)
-            textField.stringValue = "Hello"
+            textField.stringValue = ""
 
             let handled = overlayView.control(
                 textField,
                 textView: NSTextView(),
-                doCommandBy: #selector(NSResponder.insertNewline(_:))
+                doCommandBy: #selector(NSResponder.cancelOperation(_:))
             )
 
             XCTAssertTrue(handled)
-            XCTAssertEqual(
-                overlayView.currentTool, .pen,
-                "Enter should restore the previous tool when revert after placing text is on"
-            )
-            XCTAssertEqual(overlayView.textAnnotations.count, 1)
-            XCTAssertEqual(overlayView.textAnnotations[0].text, "Hello")
+            XCTAssertEqual(overlayView.textAnnotations.count, 1, "Cancelling an edit must not delete the label")
+            XCTAssertEqual(overlayView.textAnnotations[0].text, "Hi")
+            XCTAssertEqual(overlayView.currentTool, .text)
             XCTAssertNil(overlayView.activeTextField)
         }
     }
 
-    private func withReturnToPreviousToolAfterText(
+    /// Opens a new-label field at a fixed point, seeded the way `OverlayWindow` seeds it on a
+    /// click, and types `text` into it.
+    private func seedNewTextField(text: String) {
+        let point = NSPoint(x: 100, y: 100)
+        overlayView.currentTextAnnotation = TextAnnotation(
+            text: "", position: point, color: .red,
+            fontSize: defaultTextAnnotationFontSize
+        )
+        overlayView.createTextField(at: point, withText: "", width: 100)
+        overlayView.activeTextField?.stringValue = text
+    }
+
+    private func withSelectAfterPlacingText(
         _ enabled: Bool?,
         body: () throws -> Void
     ) rethrows {
-        let key = UserDefaults.returnToPreviousToolAfterTextKey
-        let saved = UserDefaults.standard.object(forKey: key)
+        let defaults = overlayView.pickerUserDefaults
+        let key = UserDefaults.selectAfterPlacingTextKey
+        let saved = defaults.object(forKey: key)
         defer {
             if let saved {
-                UserDefaults.standard.set(saved, forKey: key)
+                defaults.set(saved, forKey: key)
             } else {
-                UserDefaults.standard.removeObject(forKey: key)
+                defaults.removeObject(forKey: key)
             }
         }
 
         if let enabled {
-            UserDefaults.standard.set(enabled, forKey: key)
+            defaults.selectAfterPlacingText = enabled
         } else {
-            UserDefaults.standard.removeObject(forKey: key)
+            defaults.removeObject(forKey: key)
         }
 
         try body()

--- a/AnnotateTests/OverlayViewTests.swift
+++ b/AnnotateTests/OverlayViewTests.swift
@@ -22,6 +22,7 @@ final class OverlayViewTests: XCTestCase, Sendable {
             overlayView?.pickerUserDefaultsOverride = nil
             overlayView = nil
         }
+        TestUserDefaults.removeSuite()
         super.tearDown()
     }
 
@@ -1077,6 +1078,85 @@ final class OverlayViewTests: XCTestCase, Sendable {
             XCTAssertEqual(overlayView.textAnnotations.count, 1, "Cancelling an edit must not delete the label")
             XCTAssertEqual(overlayView.textAnnotations[0].text, "Hi")
             XCTAssertEqual(overlayView.currentTool, .text)
+            XCTAssertNil(overlayView.activeTextField)
+        }
+    }
+
+    func testCommandReturnSelectsThePlacedLabelWhenOptedIn() throws {
+        try withSelectAfterPlacingText(true) {
+            overlayView.currentTool = .text
+            seedNewTextField(text: "Hello")
+            let textField = try XCTUnwrap(overlayView.activeTextField as? AnnotationTextField)
+
+            textField.onCommandReturn?()
+
+            XCTAssertEqual(
+                overlayView.currentTool, .select,
+                "Cmd+Enter commits like Enter, including the switch"
+            )
+            XCTAssertEqual(overlayView.textAnnotations.count, 1)
+            XCTAssertEqual(overlayView.textAnnotations[0].text, "Hello")
+            XCTAssertEqual(overlayView.selectedObjects, [.text(index: 0)])
+            XCTAssertNil(overlayView.activeTextField)
+        }
+    }
+
+    func testEnterOnEmptyFieldPlacesNothingAndStaysInTextModeWhenOptedIn() throws {
+        try withSelectAfterPlacingText(true) {
+            overlayView.currentTool = .text
+            seedNewTextField(text: "")
+            let textField = try XCTUnwrap(overlayView.activeTextField)
+
+            let handled = overlayView.control(
+                textField,
+                textView: NSTextView(),
+                doCommandBy: #selector(NSResponder.insertNewline(_:))
+            )
+
+            XCTAssertTrue(handled)
+            XCTAssertTrue(overlayView.textAnnotations.isEmpty, "An empty field places no label")
+            XCTAssertEqual(
+                overlayView.currentTool, .text,
+                "There is nothing to select, so the tool stays put"
+            )
+            XCTAssertTrue(overlayView.selectedObjects.isEmpty)
+            XCTAssertNil(overlayView.activeTextField)
+        }
+    }
+
+    func testEnterOnAnEditedLabelSelectsThatLabelWhenOptedIn() throws {
+        try withSelectAfterPlacingText(true) {
+            overlayView.currentTool = .text
+            let first = TextAnnotation(
+                text: "First", position: NSPoint(x: 100, y: 100), color: .red,
+                fontSize: defaultTextAnnotationFontSize
+            )
+            let second = TextAnnotation(
+                text: "Second", position: NSPoint(x: 300, y: 300), color: .red,
+                fontSize: defaultTextAnnotationFontSize
+            )
+            overlayView.textAnnotations = [first, second]
+            overlayView.editingTextAnnotationIndex = 0
+            overlayView.currentTextAnnotation = first
+            overlayView.createTextField(at: first.position, withText: first.text, width: 300)
+            let textField = try XCTUnwrap(overlayView.activeTextField)
+            textField.stringValue = "Edited"
+
+            let handled = overlayView.control(
+                textField,
+                textView: NSTextView(),
+                doCommandBy: #selector(NSResponder.insertNewline(_:))
+            )
+
+            XCTAssertTrue(handled)
+            XCTAssertEqual(overlayView.textAnnotations.count, 2, "Editing must not add a label")
+            XCTAssertEqual(overlayView.textAnnotations[0].text, "Edited")
+            XCTAssertEqual(overlayView.textAnnotations[1].text, "Second")
+            XCTAssertEqual(
+                overlayView.selectedObjects, [.text(index: 0)],
+                "The edited label is the selection, not the last one in the array"
+            )
+            XCTAssertEqual(overlayView.currentTool, .select)
             XCTAssertNil(overlayView.activeTextField)
         }
     }

--- a/AnnotateTests/OverlayWindowTests.swift
+++ b/AnnotateTests/OverlayWindowTests.swift
@@ -27,9 +27,11 @@ final class OverlayWindowTests: XCTestCase, Sendable {
         MainActor.assumeIsolated {
             window.cancelQuickPicker()
             window.stopFadeLoop()
+            window.overlayView.pickerUserDefaultsOverride = nil
             window = nil
             NSEvent.isMouseCoalescingEnabled = originalMouseCoalescingEnabled
         }
+        TestUserDefaults.removeSuite()
         super.tearDown()
     }
 
@@ -1630,6 +1632,84 @@ final class OverlayWindowTests: XCTestCase, Sendable {
 
         XCTAssertFalse(window.performKeyEquivalent(with: cmdB))
         XCTAssertFalse(UserDefaults.standard.textBackgroundEnabled)
+    }
+
+    // MARK: - Committing a label by clicking away
+
+    func testClickingAwayPlacesTheLabelAndSwitchesToSelectWhenOptedIn() throws {
+        try seedLabelInProgress(text: "Hello", selectAfterPlacing: true)
+
+        window.mouseDown(
+            with: try XCTUnwrap(
+                TestEvents.createMouseEvent(
+                    type: .leftMouseDown,
+                    location: NSPoint(x: 400, y: 400)
+                )))
+
+        XCTAssertEqual(window.overlayView.textAnnotations.count, 1)
+        XCTAssertEqual(window.overlayView.textAnnotations[0].text, "Hello")
+        XCTAssertEqual(
+            window.overlayView.currentTool, .select,
+            "Clicking away is a commit, so it honors the switch to Select"
+        )
+        XCTAssertEqual(window.overlayView.selectedObjects, [.text(index: 0)])
+        XCTAssertNil(
+            window.overlayView.activeTextField,
+            "The click that finished the label must not open another field"
+        )
+    }
+
+    func testClickingAwayStaysInTextModeByDefault() throws {
+        try seedLabelInProgress(text: "Hello", selectAfterPlacing: false)
+
+        window.mouseDown(
+            with: try XCTUnwrap(
+                TestEvents.createMouseEvent(
+                    type: .leftMouseDown,
+                    location: NSPoint(x: 400, y: 400)
+                )))
+
+        XCTAssertEqual(window.overlayView.textAnnotations.count, 1)
+        XCTAssertEqual(window.overlayView.currentTool, .text)
+        XCTAssertTrue(window.overlayView.selectedObjects.isEmpty)
+        XCTAssertNotNil(
+            window.overlayView.activeTextField,
+            "With the setting off the click still opens the next label"
+        )
+    }
+
+    func testUndoAfterPlacingALabelClearsTheSelection() throws {
+        let textField = try seedLabelInProgress(text: "Hello", selectAfterPlacing: true)
+        window.overlayView.commitTextField(textField)
+        XCTAssertEqual(window.overlayView.selectedObjects, [.text(index: 0)])
+
+        window.overlayView.undo()
+
+        XCTAssertTrue(window.overlayView.textAnnotations.isEmpty)
+        XCTAssertTrue(
+            window.overlayView.selectedObjects.isEmpty,
+            "Undo must not leave the removed label selected"
+        )
+    }
+
+    /// Opens a text field with `text` typed into it, with the select-after-placing setting
+    /// pinned for the store the overlay view reads.
+    @discardableResult
+    private func seedLabelInProgress(text: String, selectAfterPlacing: Bool) throws -> NSTextField {
+        let defaults = TestUserDefaults.create()
+        defaults.selectAfterPlacingText = selectAfterPlacing
+        window.overlayView.pickerUserDefaultsOverride = defaults
+
+        let point = NSPoint(x: 100, y: 100)
+        window.overlayView.currentTool = .text
+        window.overlayView.currentTextAnnotation = TextAnnotation(
+            text: "", position: point, color: .red,
+            fontSize: defaultTextAnnotationFontSize
+        )
+        window.overlayView.createTextField(at: point, withText: "", width: 100)
+        let textField = try XCTUnwrap(window.overlayView.activeTextField)
+        textField.stringValue = text
+        return textField
     }
 }
 

--- a/AnnotateTests/TestHelpers.swift
+++ b/AnnotateTests/TestHelpers.swift
@@ -13,28 +13,31 @@ enum TestConstants {
 
 // MARK: - Test UserDefaults
 enum TestUserDefaults {
+    /// Every suite name `create()` has handed out, so `removeSuite()` knows what to delete.
+    /// UserDefaults does not expose the suite name of an instance, and each name is unique,
+    /// so without this registry the cleanup has nothing to remove. XCTest runs the classes
+    /// inside one process serially and splits parallel work across processes, so a process
+    /// only ever drains the suites it created itself.
+    private static var createdSuiteNames: [String] = []
+
     /// Creates a fresh isolated UserDefaults instance for testing
     /// - Returns: A new UserDefaults suite completely isolated from production data
     static func create() -> UserDefaults {
         // Unique suite per call so parallel XCTest classes cannot wipe
-        // LastUsedTool / DefaultTool out from under each other.
+        // LastUsedTool / DefaultTool out from under each other. A brand new suite is
+        // already empty, so there is nothing to clear here.
         let suiteName = "\(TestConstants.testSuiteName).\(UUID().uuidString)"
         let suite = UserDefaults(suiteName: suiteName)!
-        clear(suite)
+        createdSuiteNames.append(suiteName)
         return suite
     }
 
-    /// Clears all data from a test UserDefaults suite
-    static func clear(_ userDefaults: UserDefaults) {
-        userDefaults.dictionaryRepresentation().keys.forEach { key in
-            userDefaults.removeObject(forKey: key)
-        }
-        userDefaults.synchronize()
-    }
-
-    /// Completely removes the test suite from the system
+    /// Completely removes every test suite created in this process, so no test value is
+    /// left behind in the app container.
     static func removeSuite() {
-        UserDefaults.standard.removePersistentDomain(forName: TestConstants.testSuiteName)
+        let suiteNames = createdSuiteNames
+        createdSuiteNames.removeAll()
+        suiteNames.forEach { UserDefaults.standard.removePersistentDomain(forName: $0) }
         UserDefaults.standard.synchronize()
     }
 }

--- a/AnnotateTests/TestHelpers.swift
+++ b/AnnotateTests/TestHelpers.swift
@@ -13,31 +13,34 @@ enum TestConstants {
 
 // MARK: - Test UserDefaults
 enum TestUserDefaults {
-    /// Every suite name `create()` has handed out, so `removeSuite()` knows what to delete.
-    /// UserDefaults does not expose the suite name of an instance, and each name is unique,
-    /// so without this registry the cleanup has nothing to remove. XCTest runs the classes
-    /// inside one process serially and splits parallel work across processes, so a process
-    /// only ever drains the suites it created itself.
-    private static var createdSuiteNames: [String] = []
+    /// One suite per test process. Xcode's parallel testing isolates classes by process, so
+    /// parallel runs cannot clobber each other, and inside one process tests run serially
+    /// and `create()` clears the suite before handing it out. A per-call UUID would isolate
+    /// just as well, but the preferences daemon keeps an empty plist for every suite name
+    /// it has ever seen, which added over a hundred files to the app container per run.
+    private static let suiteName =
+        "\(TestConstants.testSuiteName).\(ProcessInfo.processInfo.processIdentifier)"
 
     /// Creates a fresh isolated UserDefaults instance for testing
-    /// - Returns: A new UserDefaults suite completely isolated from production data
+    /// - Returns: An empty UserDefaults suite completely isolated from production data
     static func create() -> UserDefaults {
-        // Unique suite per call so parallel XCTest classes cannot wipe
-        // LastUsedTool / DefaultTool out from under each other. A brand new suite is
-        // already empty, so there is nothing to clear here.
-        let suiteName = "\(TestConstants.testSuiteName).\(UUID().uuidString)"
         let suite = UserDefaults(suiteName: suiteName)!
-        createdSuiteNames.append(suiteName)
+        clear(suite)
         return suite
     }
 
-    /// Completely removes every test suite created in this process, so no test value is
-    /// left behind in the app container.
+    /// Clears all data from a test UserDefaults suite
+    static func clear(_ userDefaults: UserDefaults) {
+        userDefaults.dictionaryRepresentation().keys.forEach { key in
+            userDefaults.removeObject(forKey: key)
+        }
+        userDefaults.synchronize()
+    }
+
+    /// Completely removes this process's test suite so no test value is left behind in the
+    /// app container.
     static func removeSuite() {
-        let suiteNames = createdSuiteNames
-        createdSuiteNames.removeAll()
-        suiteNames.forEach { UserDefaults.standard.removePersistentDomain(forName: $0) }
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
         UserDefaults.standard.synchronize()
     }
 }

--- a/AnnotateTests/TestHelpers.swift
+++ b/AnnotateTests/TestHelpers.swift
@@ -16,7 +16,10 @@ enum TestUserDefaults {
     /// Creates a fresh isolated UserDefaults instance for testing
     /// - Returns: A new UserDefaults suite completely isolated from production data
     static func create() -> UserDefaults {
-        let suite = UserDefaults(suiteName: TestConstants.testSuiteName)!
+        // Unique suite per call so parallel XCTest classes cannot wipe
+        // LastUsedTool / DefaultTool out from under each other.
+        let suiteName = "\(TestConstants.testSuiteName).\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: suiteName)!
         clear(suite)
         return suite
     }

--- a/README.md
+++ b/README.md
@@ -180,14 +180,14 @@ brew install --cask annotate
 
 #### 🪟 Overlay Controls
 
-| Shortcut                                            | Action             | Description                          |
-| --------------------------------------------------- | ------------------ | ------------------------------------ |
-| Custom (Settings)                                   | **Toggle Overlay** | Show or hide the annotation overlay  |
-| Custom (Settings)                                   | **Always-On Mode** | Persistent, non-interactive display  |
-| <kbd>Esc</kbd> or <kbd>Command</kbd> + <kbd>W</kbd> | **Close**          | Closes the annotation overlay        |
-| <kbd>Shift</kbd> + <kbd>Esc</kbd>                   | **Switch Mode**    | Close interactive → enable always-on |
-| <kbd>Enter</kbd> (in text)                          | **Commit Text**    | Place the label and stay in text mode |
-| <kbd>Esc</kbd> (in text)                            | **Cancel Text**    | Discard the in-progress label        |
+| Shortcut                                            | Action                    | Description                                                       |
+| --------------------------------------------------- | ------------------------- | ----------------------------------------------------------------- |
+| Custom (Settings)                                   | **Toggle Overlay**        | Show or hide the annotation overlay                               |
+| Custom (Settings)                                   | **Always-On Mode**        | Persistent, non-interactive display                               |
+| <kbd>Esc</kbd> or <kbd>Command</kbd> + <kbd>W</kbd> | **Close**                 | Closes the annotation overlay                                     |
+| <kbd>Shift</kbd> + <kbd>Esc</kbd>                   | **Switch Mode**           | Close interactive → enable always-on                              |
+| <kbd>Enter</kbd> (in text)                          | **Commit Text**           | Place the label and stay in text mode                             |
+| <kbd>Esc</kbd> (in text)                            | **Commit or Cancel Text** | Place the label if it has text, otherwise discard the empty field |
 
 ### Drawing Tools
 
@@ -232,7 +232,7 @@ Annotate provides flexible line width control:
 #### Text Annotations
 
 - Click to place a text annotation
-- Type your text and press <kbd>Enter</kbd> to place it, or <kbd>Esc</kbd> to discard it
+- Type your text and press <kbd>Enter</kbd> or <kbd>Esc</kbd> to place it. <kbd>Esc</kbd> on an empty field discards it
 - Double-click any text annotation to edit its content
 - Click and drag to reposition text
 - Press <kbd>Command</kbd> + <kbd>+</kbd> or <kbd>Command</kbd> + <kbd>-</kbd> while typing to resize the label
@@ -340,7 +340,7 @@ Settings are organized into a sidebar with five panes: **General**, **Tools**, *
 - **Play sounds**: Play feedback sounds for overlay and clear actions.
 - **Sound Theme**: Choose between Chalk (default), Paper, Marker, Pencil, and Typewriter feedback sounds.
 - **Show in Dock**: Display Annotate icon in the Dock.
-- **Return to previous tool after placing text**: After committing a label with Enter, switch back to the last tool. Off by default so text mode stays selected.
+- **Switch to Select after placing text**: After committing a label, switch to the Select tool with that label selected. Off by default so text mode stays selected.
 - **Default Tool**: Choose which tool is selected each time the overlay is activated (defaults to last used).
 
 ### Tools

--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ brew install --cask annotate
 | Custom (Settings)                                   | **Always-On Mode**        | Persistent, non-interactive display                               |
 | <kbd>Esc</kbd> or <kbd>Command</kbd> + <kbd>W</kbd> | **Close**                 | Closes the annotation overlay                                     |
 | <kbd>Shift</kbd> + <kbd>Esc</kbd>                   | **Switch Mode**           | Close interactive → enable always-on                              |
-| <kbd>Enter</kbd> (in text)                          | **Commit Text**           | Place the label and stay in text mode                             |
+| <kbd>Enter</kbd> (in text)                          | **Commit Text**           | Place the label, switching to Select if that setting is on        |
+| <kbd>Command</kbd> + <kbd>Enter</kbd> (in text)     | **Commit Text**           | Place the label, same as Enter                                    |
 | <kbd>Esc</kbd> (in text)                            | **Commit or Cancel Text** | Place the label if it has text, otherwise discard the empty field |
 
 ### Drawing Tools
@@ -232,7 +233,7 @@ Annotate provides flexible line width control:
 #### Text Annotations
 
 - Click to place a text annotation
-- Type your text and press <kbd>Enter</kbd> or <kbd>Esc</kbd> to place it. <kbd>Esc</kbd> on an empty field discards it
+- Type your text and press <kbd>Enter</kbd> or <kbd>Esc</kbd> to place it. <kbd>Esc</kbd> on an empty field discards it, and <kbd>Esc</kbd> while editing an existing label leaves that label untouched
 - Double-click any text annotation to edit its content
 - Click and drag to reposition text
 - Press <kbd>Command</kbd> + <kbd>+</kbd> or <kbd>Command</kbd> + <kbd>-</kbd> while typing to resize the label


### PR DESCRIPTION
## Overview

Aligns the text tool with Excalidraw and tldraw conventions: the opt-in revert now lands in the Select tool with the placed label selected, and <kbd>Esc</kbd> commits a label instead of throwing it away.

Follow-up to #84.

## Motivation

- People coming from Excalidraw or tldraw expect to land in Select after placing text so they can nudge it. Reverting to the previous drawing tool was an Annotate-only behavior nobody else has.
- In both of those apps <kbd>Esc</kbd> means "done" and saves. Here it discarded the label with no undo, so a reflexive <kbd>Esc</kbd> after typing a long label lost it.
- Sticky text stays the default. Every other Annotate tool is sticky, and the opt-in covers the arrange-after-placing workflow.

## Changes

### Text commit path

- **OverlayView.swift** - Adds `commitTextField(_:)` as the commit path for every gesture that means "place this label": <kbd>Enter</kbd>, <kbd>Cmd</kbd>+<kbd>Enter</kbd>, <kbd>Esc</kbd> with text, and clicking away on the canvas. When the toggle is on it switches every window to Select and selects the label via a new `lastCommittedTextIndex`. Focus loss, toolbar actions, and closing the overlay stay on `finalizeTextAnnotation` on purpose, and the doc comment says why. <kbd>Esc</kbd> on an empty field still cancels, and cancel never touches `textAnnotations`, so <kbd>Esc</kbd> on a cleared edit keeps the original label. Removes `previousTool` and `restorePreviousTool`.
- **OverlayWindow.swift** - `mouseDown` commits through `commitTextField` and ends the click when that switched the tool, so click-away lands in Select instead of opening a fresh field at the click point.
- **OverlayView.swift** - `undo()` and `redo()` clear the selection. A selected label removed by undo left its index behind and drew a selection box at the screen origin.
- **AppDelegate.swift** - Drops the `previousTool` bookkeeping from `switchTool`.

### Setting

- **Constants.swift** - Renames the never-released key to `SelectAfterPlacingText` and adds a typed `selectAfterPlacingText` accessor, read through `pickerUserDefaults`.
- **GeneralSettingsView.swift** - Toggle is now "Switch to Select after placing text".
- **README.md** - Updates the shortcut table (conditional <kbd>Enter</kbd> row, new <kbd>Cmd</kbd>+<kbd>Enter</kbd> row), text-tool instructions, and settings bullet.

### Tests

- **OverlayViewTests.swift** - Nine tests covering <kbd>Enter</kbd>, <kbd>Cmd</kbd>+<kbd>Enter</kbd>, and <kbd>Esc</kbd> with the toggle on and off, <kbd>Enter</kbd> and <kbd>Esc</kbd> on an empty field, <kbd>Esc</kbd> on a cleared edit, and editing an existing label.
- **OverlayWindowTests.swift** - Click-away with the toggle on and off, and undo after placing a label.
- **AppDelegateTests.swift** - Removes the two previous-tool tests; the last-used-tool test now asserts the switch lands on Select without persisting it.
- **GeneralSettingsViewTests.swift** - Renames the toggle tests to the new key.
- **TestHelpers.swift** - `TestUserDefaults` uses one suite per test process instead of the shared name, so parallel runs cannot wipe `DefaultTool` out from under each other, and `removeSuite()` removes the suite that was actually created.
- **BoardViewTests.swift** - Pins a known opacity and uses an isolated `BoardManager` so shared state from other suites cannot make the color assertion a no-op.

## Breaking Changes

None. The old key never shipped in a release.

## Testing

- [x] Full suite: 498 tests, 0 failures, serial and with `-parallel-testing-enabled YES`
- [x] Manual: <kbd>Enter</kbd>, <kbd>Cmd</kbd>+<kbd>Enter</kbd>, <kbd>Esc</kbd>, and click-away stay in text mode with the toggle off and land in Select with the label highlighted when on
- [x] Manual: <kbd>Esc</kbd> on an empty field discards it and stays in text mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to switch to Select mode and automatically select a label after placing text.
  * Pressing Esc now commits non-empty text; empty text is discarded.

* **Bug Fixes**
  * Preserved the last-used tool when text placement switches tools.
  * Prevented stale selections from appearing after undo or redo.
  * Clicking away from active text now commits it consistently.

* **Documentation**
  * Updated settings and control descriptions for text committing, canceling, and post-placement selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
