### PR TITLE
fix(toolbar): Don't change tools when dragging the floating bar

### DIFF
--- a/Annotate/ToolbarPanel.swift
+++ b/Annotate/ToolbarPanel.swift
@@ -35,10 +35,19 @@ final class ToolbarPanel: NSPanel {
     private var isUserDragging = false
     /// A move seen during a drag that still has to be written down when the drag ends.
     private var hasPendingSave = false
+    /// Tells a chip click from a drag of the bar. Shared with the SwiftUI action closure so a
+    /// Button mouse-up that lands after the bar has moved can still be refused.
+    private let press: ToolbarPress
+    private let performAction: (ToolbarAction) -> Void
 
     init(overlay: OverlayWindow, model: ToolbarModel, perform: @escaping (ToolbarAction) -> Void) {
         self.overlay = overlay
-        host = ToolbarHostingView(rootView: ToolbarView(model: model, perform: perform))
+        self.performAction = perform
+        let press = ToolbarPress()
+        self.press = press
+        host = ToolbarHostingView(rootView: ToolbarView(model: model, perform: { action in
+            press.deliver { perform(action) }
+        }))
         measurer = NSHostingController(rootView: ToolbarView(model: model) { _ in })
 
         super.init(
@@ -79,12 +88,22 @@ final class ToolbarPanel: NSPanel {
     /// `isMovableByWindowBackground` can swallow the press before `mouseDown` ever runs, and a
     /// native move like that reports a move per frame of the drag, so the flag has to be set
     /// here rather than in `mouseDown` alone or those frames would each be written down.
+    ///
+    /// Chip actions are judged here too. SwiftUI's `Button` fires on mouse-up if the pointer is
+    /// still inside the control; the bar travels with the pointer, so that test is always true
+    /// during a drag. Screen-space travel (and the bar's own origin, when AppKit swallows the
+    /// dragged events) is what actually tells a click from a drag.
     override func sendEvent(_ event: NSEvent) {
         switch event.type {
         case .leftMouseDown:
             isUserDragging = true
+            press.begin(screenPoint: screenPoint(for: event), windowOrigin: frame.origin)
+            super.sendEvent(event)
+        case .leftMouseDragged:
+            press.consider(screenPoint: screenPoint(for: event), windowOrigin: frame.origin)
             super.sendEvent(event)
         case .leftMouseUp:
+            press.consider(screenPoint: screenPoint(for: event), windowOrigin: frame.origin)
             super.sendEvent(event)
             endUserDrag()
         default:
@@ -99,6 +118,9 @@ final class ToolbarPanel: NSPanel {
     override func mouseDown(with event: NSEvent) {
         isUserDragging = true
         performDrag(with: event)
+        // `performDrag` swallows dragged events, so judge the gesture against the bar's origin
+        // before closing it. Chip actions are refused while `press.isDrag` is still set.
+        press.consider(windowOrigin: frame.origin)
         // `performDrag` may swallow the whole gesture, mouse-up included, in which case
         // `sendEvent` never sees the end of it and this is the only place left to close it.
         // The button being back up is what tells the two apart: if it is still down the drag
@@ -112,9 +134,24 @@ final class ToolbarPanel: NSPanel {
     /// did not choose. Safe to call more than once for the same gesture.
     private func endUserDrag() {
         isUserDragging = false
+        press.end()
         guard hasPendingSave else { return }
         hasPendingSave = false
         savePosition()
+    }
+
+    /// Chip actions from the SwiftUI bar. Refuses the action when the in-flight press has
+    /// already turned into a drag, so moving the bar cannot change the tool.
+    func performChipAction(_ action: ToolbarAction) {
+        press.deliver { performAction(action) }
+    }
+
+    /// True between mouse-down and mouse-up once the press has moved far enough to count as a
+    /// drag rather than a chip click.
+    var isSuppressingChipAction: Bool { press.isDrag }
+
+    private func screenPoint(for event: NSEvent) -> NSPoint {
+        convertToScreen(NSRect(origin: event.locationInWindow, size: .zero)).origin
     }
 
     // MARK: - Attachment
@@ -239,6 +276,7 @@ final class ToolbarPanel: NSPanel {
         lastKnownOffset = offset
         if isUserDragging {
             hasPendingSave = true
+            press.consider(windowOrigin: frame.origin)
         } else {
             savePosition()
         }
@@ -292,6 +330,52 @@ final class ToolbarPanel: NSPanel {
                 as? NSNumber
         else { return nil }
         return number.stringValue
+    }
+}
+
+/// Distinguishes a chip click from a drag of the floating bar.
+///
+/// SwiftUI's `Button` fires on mouse-up when the pointer is still inside the control. The bar
+/// travels with the pointer, so that test is always true during a drag. The press has to be
+/// judged in screen space instead, and against the bar's own origin when AppKit swallows the
+/// dragged events (the `performDrag` fallback).
+final class ToolbarPress {
+    static let dragThreshold: CGFloat = 4
+
+    private var startScreenPoint: NSPoint?
+    private var startWindowOrigin: NSPoint?
+    private(set) var isDrag = false
+
+    func begin(screenPoint: NSPoint, windowOrigin: NSPoint) {
+        startScreenPoint = screenPoint
+        startWindowOrigin = windowOrigin
+        isDrag = false
+    }
+
+    func consider(screenPoint: NSPoint? = nil, windowOrigin: NSPoint? = nil) {
+        guard !isDrag else { return }
+        if let start = startScreenPoint, let point = screenPoint,
+            hypot(point.x - start.x, point.y - start.y) >= Self.dragThreshold
+        {
+            isDrag = true
+            return
+        }
+        if let start = startWindowOrigin, let origin = windowOrigin,
+            hypot(origin.x - start.x, origin.y - start.y) >= Self.dragThreshold
+        {
+            isDrag = true
+        }
+    }
+
+    func end() {
+        startScreenPoint = nil
+        startWindowOrigin = nil
+        isDrag = false
+    }
+
+    func deliver(_ body: () -> Void) {
+        guard !isDrag else { return }
+        body()
     }
 }
 

--- a/Annotate/ToolbarPanel.swift
+++ b/Annotate/ToolbarPanel.swift
@@ -38,11 +38,9 @@ final class ToolbarPanel: NSPanel {
     /// Tells a chip click from a drag of the bar. Shared with the SwiftUI action closure so a
     /// Button mouse-up that lands after the bar has moved can still be refused.
     private let press: ToolbarPress
-    private let performAction: (ToolbarAction) -> Void
 
     init(overlay: OverlayWindow, model: ToolbarModel, perform: @escaping (ToolbarAction) -> Void) {
         self.overlay = overlay
-        self.performAction = perform
         let press = ToolbarPress()
         self.press = press
         host = ToolbarHostingView(rootView: ToolbarView(model: model, perform: { action in
@@ -138,12 +136,6 @@ final class ToolbarPanel: NSPanel {
         guard hasPendingSave else { return }
         hasPendingSave = false
         savePosition()
-    }
-
-    /// Chip actions from the SwiftUI bar. Refuses the action when the in-flight press has
-    /// already turned into a drag, so moving the bar cannot change the tool.
-    func performChipAction(_ action: ToolbarAction) {
-        press.deliver { performAction(action) }
     }
 
     /// True between mouse-down and mouse-up once the press has moved far enough to count as a

--- a/AnnotateTests/ToolbarTests.swift
+++ b/AnnotateTests/ToolbarTests.swift
@@ -131,6 +131,90 @@ final class ToolbarTests: XCTestCase {
         XCTAssertEqual(stored, [200, 350])
     }
 
+    func testADragDoesNotChangeTheToolEvenWhenThePointerStaysOnTheChip() throws {
+        let panel = try XCTUnwrap(window.toolbarPanel)
+        let spy = ToolbarAppDelegateSpy(userDefaults: defaults)
+        AppDelegate.shared = spy
+        defer { AppDelegate.shared = appDelegate }
+
+        // Same miss as the persistence drag test: inside-panel coordinates would reach the
+        // hosting view and start a real performDrag. The bookkeeping is what we need here.
+        let miss = NSPoint(x: panel.frame.width / 2, y: -50)
+        panel.sendEvent(
+            try XCTUnwrap(
+                TestEvents.createMouseEvent(
+                    type: .leftMouseDown, location: miss, windowNumber: panel.windowNumber)))
+
+        let origin = panel.frame.origin
+        panel.setFrameOrigin(NSPoint(x: origin.x + 80, y: origin.y + 50))
+        NotificationCenter.default.post(name: NSWindow.didMoveNotification, object: panel)
+
+        XCTAssertTrue(
+            panel.isSuppressingChipAction,
+            "The bar moved with the press; a chip mouse-up must not count as choosing a tool")
+        panel.performChipAction(.tool(.highlighter))
+        XCTAssertNil(
+            spy.selectedTool,
+            "A drag that started on a chip must not switch tools — the chip rides with the pointer")
+
+        panel.sendEvent(
+            try XCTUnwrap(
+                TestEvents.createMouseEvent(
+                    type: .leftMouseUp, location: miss, windowNumber: panel.windowNumber)))
+
+        XCTAssertFalse(panel.isSuppressingChipAction)
+        panel.performChipAction(.tool(.highlighter))
+        XCTAssertEqual(
+            spy.selectedTool, .highlighter,
+            "A chip click after the drag has ended must still switch tools")
+    }
+
+    func testPointerTravelPastTheThresholdSuppressesTheChipWithoutMovingTheBar() throws {
+        let panel = try XCTUnwrap(window.toolbarPanel)
+        let spy = ToolbarAppDelegateSpy(userDefaults: defaults)
+        AppDelegate.shared = spy
+        defer { AppDelegate.shared = appDelegate }
+
+        let start = NSPoint(x: panel.frame.width / 2, y: -50)
+        panel.sendEvent(
+            try XCTUnwrap(
+                TestEvents.createMouseEvent(
+                    type: .leftMouseDown, location: start, windowNumber: panel.windowNumber)))
+        panel.sendEvent(
+            try XCTUnwrap(
+                TestEvents.createMouseEvent(
+                    type: .leftMouseDragged,
+                    location: NSPoint(x: start.x + ToolbarPress.dragThreshold + 1, y: start.y),
+                    windowNumber: panel.windowNumber)))
+
+        XCTAssertTrue(
+            panel.isSuppressingChipAction,
+            "A clamped bar that cannot follow the pointer still has to treat this as a drag")
+        panel.performChipAction(.tool(.rectangle))
+        XCTAssertNil(spy.selectedTool)
+    }
+
+    func testAChipClickWithoutADragStillChangesTheTool() throws {
+        let panel = try XCTUnwrap(window.toolbarPanel)
+        let spy = ToolbarAppDelegateSpy(userDefaults: defaults)
+        AppDelegate.shared = spy
+        defer { AppDelegate.shared = appDelegate }
+
+        let miss = NSPoint(x: panel.frame.width / 2, y: -50)
+        panel.sendEvent(
+            try XCTUnwrap(
+                TestEvents.createMouseEvent(
+                    type: .leftMouseDown, location: miss, windowNumber: panel.windowNumber)))
+        panel.sendEvent(
+            try XCTUnwrap(
+                TestEvents.createMouseEvent(
+                    type: .leftMouseUp, location: miss, windowNumber: panel.windowNumber)))
+
+        XCTAssertFalse(panel.isSuppressingChipAction)
+        panel.performChipAction(.tool(.arrow))
+        XCTAssertEqual(spy.selectedTool, .arrow)
+    }
+
     func testAStoredPositionIsRestoredOnAFreshOverlayForTheSameDisplay() throws {
         let key = try XCTUnwrap(ToolbarPanel.displayKey(for: window))
         defaults.set([key: [140.0, 500.0]], forKey: UserDefaults.toolbarPositionsKey)
@@ -700,5 +784,72 @@ private final class ToolbarAppDelegateSpy: AppDelegate {
 
     override func toggleFadeMode(_ sender: Any?) {
         didToggleFade = true
+    }
+}
+
+@MainActor
+final class ToolbarPressTests: XCTestCase {
+    func testAStationaryPressIsAClick() {
+        let press = ToolbarPress()
+        press.begin(screenPoint: NSPoint(x: 100, y: 80), windowOrigin: NSPoint(x: 40, y: 20))
+        press.consider(screenPoint: NSPoint(x: 100, y: 80), windowOrigin: NSPoint(x: 40, y: 20))
+        XCTAssertFalse(press.isDrag)
+    }
+
+    func testPointerTravelAtTheThresholdIsADrag() {
+        let press = ToolbarPress()
+        press.begin(screenPoint: .zero, windowOrigin: .zero)
+        press.consider(
+            screenPoint: NSPoint(x: ToolbarPress.dragThreshold, y: 0), windowOrigin: .zero)
+        XCTAssertTrue(press.isDrag)
+    }
+
+    func testPointerTravelJustBelowTheThresholdIsAClick() {
+        let press = ToolbarPress()
+        press.begin(screenPoint: .zero, windowOrigin: .zero)
+        press.consider(
+            screenPoint: NSPoint(x: ToolbarPress.dragThreshold - 0.5, y: 0), windowOrigin: .zero)
+        XCTAssertFalse(press.isDrag)
+    }
+
+    func testTheBarMovingAtTheThresholdIsADragEvenIfThePointerStaysInTheChip() {
+        let press = ToolbarPress()
+        let pointer = NSPoint(x: 50, y: 20)
+        press.begin(screenPoint: pointer, windowOrigin: NSPoint(x: 100, y: 80))
+        press.consider(
+            screenPoint: pointer,
+            windowOrigin: NSPoint(x: 100 + ToolbarPress.dragThreshold, y: 80))
+        XCTAssertTrue(
+            press.isDrag,
+            "The chip rides with the bar, so a drag cannot be judged by the pointer staying inside it")
+    }
+
+    func testEndClearsTheDragSoTheNextClickCanFire() {
+        let press = ToolbarPress()
+        press.begin(screenPoint: .zero, windowOrigin: .zero)
+        press.consider(screenPoint: NSPoint(x: 40, y: 0), windowOrigin: .zero)
+        XCTAssertTrue(press.isDrag)
+
+        press.end()
+        XCTAssertFalse(press.isDrag)
+
+        press.begin(screenPoint: .zero, windowOrigin: .zero)
+        press.consider(screenPoint: .zero, windowOrigin: .zero)
+        XCTAssertFalse(press.isDrag)
+    }
+
+    func testDeliverSkipsTheActionDuringADragAndRunsItOnAClick() {
+        let press = ToolbarPress()
+        var delivered: ToolType?
+
+        press.begin(screenPoint: .zero, windowOrigin: .zero)
+        press.consider(screenPoint: NSPoint(x: 40, y: 0), windowOrigin: .zero)
+        press.deliver { delivered = .highlighter }
+        XCTAssertNil(delivered)
+
+        press.end()
+        press.begin(screenPoint: .zero, windowOrigin: .zero)
+        press.deliver { delivered = .arrow }
+        XCTAssertEqual(delivered, .arrow)
     }
 }

--- a/AnnotateTests/ToolbarTests.swift
+++ b/AnnotateTests/ToolbarTests.swift
@@ -133,6 +133,7 @@ final class ToolbarTests: XCTestCase {
 
     func testADragDoesNotChangeTheToolEvenWhenThePointerStaysOnTheChip() throws {
         let panel = try XCTUnwrap(window.toolbarPanel)
+        let host = try XCTUnwrap(panel.contentView as? ToolbarHostingView)
         let spy = ToolbarAppDelegateSpy(userDefaults: defaults)
         AppDelegate.shared = spy
         defer { AppDelegate.shared = appDelegate }
@@ -152,7 +153,7 @@ final class ToolbarTests: XCTestCase {
         XCTAssertTrue(
             panel.isSuppressingChipAction,
             "The bar moved with the press; a chip mouse-up must not count as choosing a tool")
-        panel.performChipAction(.tool(.highlighter))
+        host.rootView.perform(.tool(.highlighter))
         XCTAssertNil(
             spy.selectedTool,
             "A drag that started on a chip must not switch tools — the chip rides with the pointer")
@@ -163,7 +164,7 @@ final class ToolbarTests: XCTestCase {
                     type: .leftMouseUp, location: miss, windowNumber: panel.windowNumber)))
 
         XCTAssertFalse(panel.isSuppressingChipAction)
-        panel.performChipAction(.tool(.highlighter))
+        host.rootView.perform(.tool(.highlighter))
         XCTAssertEqual(
             spy.selectedTool, .highlighter,
             "A chip click after the drag has ended must still switch tools")
@@ -171,6 +172,7 @@ final class ToolbarTests: XCTestCase {
 
     func testPointerTravelPastTheThresholdSuppressesTheChipWithoutMovingTheBar() throws {
         let panel = try XCTUnwrap(window.toolbarPanel)
+        let host = try XCTUnwrap(panel.contentView as? ToolbarHostingView)
         let spy = ToolbarAppDelegateSpy(userDefaults: defaults)
         AppDelegate.shared = spy
         defer { AppDelegate.shared = appDelegate }
@@ -190,12 +192,13 @@ final class ToolbarTests: XCTestCase {
         XCTAssertTrue(
             panel.isSuppressingChipAction,
             "A clamped bar that cannot follow the pointer still has to treat this as a drag")
-        panel.performChipAction(.tool(.rectangle))
+        host.rootView.perform(.tool(.rectangle))
         XCTAssertNil(spy.selectedTool)
     }
 
     func testAChipClickWithoutADragStillChangesTheTool() throws {
         let panel = try XCTUnwrap(window.toolbarPanel)
+        let host = try XCTUnwrap(panel.contentView as? ToolbarHostingView)
         let spy = ToolbarAppDelegateSpy(userDefaults: defaults)
         AppDelegate.shared = spy
         defer { AppDelegate.shared = appDelegate }
@@ -211,7 +214,7 @@ final class ToolbarTests: XCTestCase {
                     type: .leftMouseUp, location: miss, windowNumber: panel.windowNumber)))
 
         XCTAssertFalse(panel.isSuppressingChipAction)
-        panel.performChipAction(.tool(.arrow))
+        host.rootView.perform(.tool(.arrow))
         XCTAssertEqual(spy.selectedTool, .arrow)
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the draggable toolbar (#87). Dragging the bar must not change tools.

## Summary

- SwiftUI's `Button` fires on mouse-up if the pointer is still inside the chip. The floating bar travels with the pointer, so a drag that starts on a tool also selected it.
- `ToolbarPanel` now judges the press in screen space (and against the bar's own origin when AppKit swallows dragged events) and refuses the chip action once it has moved past a 4pt threshold.
- Plain chip clicks still switch tools. Color, width, fade, and action chips use the same gate.

## Testing

- Unit tests cover: pointer travel at / below the threshold, the bar moving while the pointer stays on the chip, `deliver` skipping during a drag, a panel drag not switching tools, pointer travel without the bar moving, and a click still switching tools.
- `xcodebuild` was not run here (per request). CI on this PR will exercise the suite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0c1c032-1145-45e7-8c34-1372861f87b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0c1c032-1145-45e7-8c34-1372861f87b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Toolbar chip actions are now triggered only by clicks, not while moving or dragging the floating toolbar.
  - Dragging the toolbar no longer causes unintended actions.
  - Toolbar interactions now correctly distinguish clicks from movement, including movement of the toolbar itself.
  - Toolbar controls now reset their interaction state correctly after dragging, ensuring subsequent clicks respond as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->