### PR TITLE
feat(toolbar): Add a neutral sliding glass selection

### DIFF
--- a/Annotate/ToolbarView.swift
+++ b/Annotate/ToolbarView.swift
@@ -32,8 +32,7 @@ final class ToolbarModel: ObservableObject {
 struct ToolbarView: View {
     @ObservedObject var model: ToolbarModel
     let perform: (ToolbarAction) -> Void
-
-    private static let chipCornerRadius: CGFloat = 11
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let spring = Animation.spring(response: 0.24, dampingFraction: 0.72)
 
@@ -52,29 +51,38 @@ struct ToolbarView: View {
                 }
             }
         }
-        .animation(spring, value: model.activeTool)
+        .animation(reduceMotion ? nil : spring, value: model.activeTool)
         .animation(spring, value: model.currentColor)
         .animation(spring, value: model.currentWidth)
         .animation(spring, value: model.fadeMode)
     }
 
     private var toolsSegment: some View {
-        segment {
+        HStack(spacing: 2) {
             ForEach(ToolType.allCases, id: \.self) { tool in
                 toolbarButton(identifier: "toolbar.tool.\(tool.rawValue)", action: {
                     perform(.tool(tool))
                 }) {
                     let active = model.activeTool == tool
                     chip(symbol: tool.symbolName, keycap: shortcut(for: tool.shortcutKey), active: active)
-                        .background {
-                            if active {
-                                RoundedRectangle(cornerRadius: Self.chipCornerRadius)
-                                    .fill(Color(nsColor: model.currentColor))
-                            }
+                        .anchorPreference(key: SelectedToolBounds.self, value: .bounds) {
+                            active ? $0 : nil
                         }
                 }
             }
         }
+        .backgroundPreferenceValue(SelectedToolBounds.self) { anchor in
+            GeometryReader { proxy in
+                if let anchor {
+                    let bounds = proxy[anchor]
+                    ToolbarSelectionLens(tint: Color(nsColor: model.currentColor))
+                        .frame(width: bounds.width, height: bounds.height)
+                        .position(x: bounds.midX, y: bounds.midY)
+                        .animation(reduceMotion ? nil : spring, value: bounds)
+                }
+            }
+        }
+        .toolbarSegment()
     }
 
     private var stateSegment: some View {
@@ -104,8 +112,7 @@ struct ToolbarView: View {
                 chip(symbol: "circle.lefthalf.filled", keycap: "␣", active: model.fadeMode)
                     .background {
                         if model.fadeMode {
-                            RoundedRectangle(cornerRadius: Self.chipCornerRadius)
-                                .fill(Color.primary.opacity(0.14))
+                            ToolbarSelectionLens()
                         }
                     }
             }
@@ -128,10 +135,7 @@ struct ToolbarView: View {
 
     private func segment<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         HStack(spacing: 2) { content() }
-            .padding(5)
-            .toolbarGlassSegment()
-            .shadow(color: .black.opacity(0.28), radius: 14, y: 5)
-            .fixedSize()
+            .toolbarSegment()
     }
 
     private func toolbarButton<Label: View>(
@@ -147,20 +151,16 @@ struct ToolbarView: View {
         HStack(spacing: 6) {
             Image(systemName: symbol)
                 .font(.system(size: 13, weight: .medium))
-            keycap(text, lit: active, inverted: active)
+            keycap(text, lit: active)
         }
-        .foregroundStyle(active ? Color.white : Color.primary.opacity(0.76))
+        .foregroundStyle(Color.primary.opacity(active ? 1 : 0.76))
         .chipPadding()
     }
 
-    private func keycap(_ text: String, lit: Bool = false, inverted: Bool = false) -> some View {
+    private func keycap(_ text: String, lit: Bool = false) -> some View {
         Text(text.uppercased())
             .font(.system(size: 10, weight: .bold, design: .monospaced))
-            .foregroundStyle(
-                inverted
-                    ? Color.white.opacity(0.95)
-                    : Color.primary.opacity(lit ? 0.95 : 0.58)
-            )
+            .foregroundStyle(Color.primary.opacity(lit ? 0.95 : 0.58))
             .fixedSize()
             .padding(.horizontal, 4)
             .padding(.vertical, 2)
@@ -175,7 +175,22 @@ struct ToolbarView: View {
     }
 }
 
+private struct SelectedToolBounds: PreferenceKey {
+    static var defaultValue: Anchor<CGRect>? { nil }
+
+    static func reduce(value: inout Anchor<CGRect>?, nextValue: () -> Anchor<CGRect>?) {
+        value = nextValue() ?? value
+    }
+}
+
 private extension View {
+    func toolbarSegment() -> some View {
+        padding(5)
+            .toolbarGlassSegment()
+            .shadow(color: .black.opacity(0.28), radius: 14, y: 5)
+            .fixedSize()
+    }
+
     func chipPadding() -> some View {
         padding(.horizontal, 9)
             .padding(.vertical, 7)

--- a/Annotate/ToolbarView.swift
+++ b/Annotate/ToolbarView.swift
@@ -187,7 +187,6 @@ private extension View {
     func toolbarSegment() -> some View {
         padding(5)
             .toolbarGlassSegment()
-            .shadow(color: .black.opacity(0.28), radius: 14, y: 5)
             .fixedSize()
     }
 

--- a/Annotate/ToolbarView.swift
+++ b/Annotate/ToolbarView.swift
@@ -75,7 +75,7 @@ struct ToolbarView: View {
             GeometryReader { proxy in
                 if let anchor {
                     let bounds = proxy[anchor]
-                    ToolbarSelectionLens(tint: Color(nsColor: model.currentColor))
+                    ToolbarSelectionLens()
                         .frame(width: bounds.width, height: bounds.height)
                         .position(x: bounds.midX, y: bounds.midY)
                         .animation(reduceMotion ? nil : spring, value: bounds)

--- a/Annotate/View+LiquidGlass.swift
+++ b/Annotate/View+LiquidGlass.swift
@@ -3,7 +3,6 @@ import SwiftUI
 /// The segment supplies the refractive glass. This lens adds relief within that
 /// surface without nesting another glass effect, which can obscure chip content.
 struct ToolbarSelectionLens: View {
-    var tint: Color = .clear
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.colorSchemeContrast) private var contrast
@@ -28,16 +27,6 @@ struct ToolbarSelectionLens: View {
                 if reduceTransparency {
                     shape.fill(Color(nsColor: .controlBackgroundColor))
                 }
-            }
-            .overlay {
-                shape.fill(
-                    RadialGradient(
-                        colors: [tint.opacity(0.22), tint.opacity(0)],
-                        center: .bottom,
-                        startRadius: 0,
-                        endRadius: 38
-                    )
-                )
             }
             .overlay {
                 shape.strokeBorder(Color.primary.opacity(contrast == .increased ? 0.6 : 0.16), lineWidth: 1)

--- a/Annotate/View+LiquidGlass.swift
+++ b/Annotate/View+LiquidGlass.swift
@@ -1,5 +1,67 @@
 import SwiftUI
 
+/// The segment supplies the refractive glass. This lens adds relief within that
+/// surface without nesting another glass effect, which can obscure chip content.
+struct ToolbarSelectionLens: View {
+    var tint: Color = .clear
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    private let shape = RoundedRectangle(cornerRadius: 11, style: .continuous)
+
+    var body: some View {
+        shape
+            .fill(
+                LinearGradient(
+                    stops: [
+                        .init(color: .white.opacity(colorScheme == .dark ? 0.25 : 0.6), location: 0),
+                        .init(color: .white.opacity(0.10), location: 0.48),
+                        .init(color: .black.opacity(0.06), location: 0.75),
+                        .init(color: .white.opacity(0.16), location: 1),
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .background {
+                if reduceTransparency {
+                    shape.fill(Color(nsColor: .controlBackgroundColor))
+                }
+            }
+            .overlay {
+                shape.fill(
+                    RadialGradient(
+                        colors: [tint.opacity(0.22), tint.opacity(0)],
+                        center: .bottom,
+                        startRadius: 0,
+                        endRadius: 38
+                    )
+                )
+            }
+            .overlay {
+                shape.strokeBorder(Color.primary.opacity(contrast == .increased ? 0.6 : 0.16), lineWidth: 1)
+            }
+            .overlay {
+                shape.inset(by: 0.5).strokeBorder(
+                    LinearGradient(
+                        stops: [
+                            .init(color: .white.opacity(0.65), location: 0),
+                            .init(color: .white.opacity(0.08), location: 0.5),
+                            .init(color: .white.opacity(0.3), location: 1),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 0.5
+                )
+            }
+            .shadow(color: .black.opacity(0.16), radius: 2, y: 1)
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+    }
+}
+
 extension View {
     /// Applies a soft scroll edge effect on macOS 26 (Liquid Glass) so
     /// scrollable settings content blends into the window chrome.


### PR DESCRIPTION
## Overview

Replaces the solid drawing-color selection with a neutral, layered glass lens that slides and resizes between tools. Glyphs and shortcut keycaps remain legible regardless of the drawing color, and Fade uses the same selected-state styling.

## Motivation

The solid fill duplicated the color swatch and lost contrast with light drawing colors. The toolbar's oversized segment shadows also clipped against the floating window, leaving a hard gray rectangle on white backgrounds.

## Screenshots

Neutral selection with Pen active and Fade enabled.

### Light background

![Toolbar with neutral selection on a light background](https://github.com/user-attachments/assets/1d101917-3450-47a4-a43d-d1d261ae28ff)

### Dark background

![Toolbar with neutral selection on a dark background](https://github.com/user-attachments/assets/f440867d-338c-4285-b837-36ef69ac9619)

## Changes

### Toolbar selection

- **ToolbarView.swift** - Keeps one lens behind the tool row and animates its bounds with the existing spring. Preserves hover scaling, respects Reduce Motion, and removes the clipped outer shadow.
- **View+LiquidGlass.swift** - Adds a neutral lens with layered highlights, a subtle rim, and a soft shadow. Keeps macOS 14 compatibility and supports Reduce Transparency and increased contrast.

## Breaking Changes

None

## Testing

- [x] Regenerated the project with `xcodegen generate` and built the Debug scheme.
- [x] Both existing toolbar wrapping tests pass with the sliding lens.
- [x] Verified tool switching in the running app with a frame-by-frame recording.
- [x] Checked neutral selection on light and dark backgrounds and confirmed the clipped shadow is gone on white.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the annotation toolbar with a consistent glass-style selection highlight across active tools, fade mode, and color/width indicators.
  * Standardized spacing, sizing, backgrounds, and shadows across toolbar segments.
  * Improved visual contrast and appearance when increased contrast or reduced transparency is enabled.

* **Accessibility**
  * Reduced selection-highlight animation when Reduce Motion is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
