### PR TITLE
test(cursor): Restore spotlight and dimming visibility coverage

### DIFF
--- a/Annotate/CursorHighlightView.swift
+++ b/Annotate/CursorHighlightView.swift
@@ -56,6 +56,7 @@ class CursorHighlightView: NSView {
     private func setupLayers() {
         // Dimming layer (darkens everything except a hole around the cursor)
         let dimming = CAShapeLayer()
+        dimming.name = "dimming"
         dimming.fillRule = .evenOdd
         dimming.fillColor = Self.blackCG
         dimming.lineWidth = 0
@@ -65,6 +66,7 @@ class CursorHighlightView: NSView {
 
         // Spotlight layer (follows cursor when enabled)
         let spotlight = CAShapeLayer()
+        spotlight.name = "spotlight"
         spotlight.lineWidth = 0
         spotlight.opacity = 0
         layer?.addSublayer(spotlight)

--- a/AnnotateTests/CursorHighlightWindowTests.swift
+++ b/AnnotateTests/CursorHighlightWindowTests.swift
@@ -24,7 +24,7 @@ final class CursorHighlightWindowTests: XCTestCase {
         XCTAssertNil(window.animationDisplayLink)
     }
 
-    func testUpdateVisibilityHidesSpotlightImmediatelyWhenClickEffectsKeepWindowAlive() throws {
+    func testUpdateVisibilityHidesSpotlightAndDimmingImmediatelyWhenClickEffectsKeepWindowAlive() throws {
         let defaults = TestUserDefaults.create()
         let originalShared = CursorHighlightManager.shared
         let manager = CursorHighlightManager(userDefaults: defaults)
@@ -46,8 +46,11 @@ final class CursorHighlightWindowTests: XCTestCase {
         manager.cursorHighlightEnabled = false
         manager.spotlightRequiresOverlay = false
 
-        let spotlight = try XCTUnwrap(window.highlightView.layer?.sublayers?.first)
+        let layers = try XCTUnwrap(window.highlightView.layer?.sublayers)
+        let spotlight = try XCTUnwrap(layers.first { $0.name == "spotlight" })
+        let dimming = try XCTUnwrap(layers.first { $0.name == "dimming" })
         spotlight.opacity = 1
+        dimming.opacity = 1
 
         window.updateVisibility()
 
@@ -55,6 +58,11 @@ final class CursorHighlightWindowTests: XCTestCase {
             spotlight.opacity,
             0,
             "Spotlight should hide as soon as it is disabled, even if click effects keep the window ordered in"
+        )
+        XCTAssertEqual(
+            dimming.opacity,
+            0,
+            "Dimming should hide as soon as the spotlight is disabled, even if click effects keep the window ordered in"
         )
     }
 }


### PR DESCRIPTION
Restores the spotlight visibility regression test after #91 inserted dimming as the first sublayer. Names both layers so the test selects them explicitly and verifies that both hide immediately when click effects keep the window alive.

Validation: `swift test --filter CursorHighlightWindowTests` passed (2 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor highlighting behavior so disabling highlighting immediately hides both the spotlight and dimming effects while preserving click interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->