### PR TITLE
feat(cursor): Add an optional background dimming shortcut

### DIFF
--- a/Annotate/CursorHighlightManager.swift
+++ b/Annotate/CursorHighlightManager.swift
@@ -152,6 +152,16 @@ class CursorHighlightManager: @unchecked Sendable {
 
     // MARK: - Background Dimming Settings
 
+    /// Enables the spotlight if needed, then toggles dimming without changing click effects.
+    func toggleSpotlightDimming() {
+        if !cursorHighlightEnabled {
+            cursorHighlightEnabled = true
+            spotlightDimmingEnabled = true
+        } else {
+            spotlightDimmingEnabled.toggle()
+        }
+    }
+
     /// Whether the screen darkens around the spotlight, leaving a clear area at the cursor.
     var spotlightDimmingEnabled: Bool {
         get { userDefaults.bool(forKey: UserDefaults.spotlightDimmingEnabledKey) }

--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -1536,6 +1536,7 @@ class OverlayWindow: NSPanel {
         
         // Handle single-key shortcuts if no modifiers are pressed
         if !cmdPressed
+            && !key.isEmpty
             && event.modifierFlags.intersection([.command, .option, .control, .shift]).isEmpty
         {
             switch key {
@@ -1581,6 +1582,17 @@ class OverlayWindow: NSPanel {
                 return
             case ShortcutManager.shared.getShortcut(for: .toggleClickEffects):
                 AppDelegate.shared?.toggleClickEffects(nil)
+                return
+            case ShortcutManager.shared.getShortcut(for: .toggleBackgroundDimming):
+                if isEditingAnnotationText { break }
+                if !event.isARepeat {
+                    let manager = CursorHighlightManager.shared
+                    manager.toggleSpotlightDimming()
+                    showToggleFeedback(
+                        manager.spotlightDimmingEnabled ? "Dimming On" : "Dimming Off",
+                        icon: manager.spotlightDimmingEnabled ? "🌘" : "☀️"
+                    )
+                }
                 return
             default:
                 break

--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -721,6 +721,10 @@ class OverlayWindow: NSPanel {
             if performToolShortcut(mappedTo: key) {
                 return true
             }
+            if key == ShortcutManager.shared.getShortcut(for: .toggleBackgroundDimming) {
+                toggleBackgroundDimming(with: event)
+                return true
+            }
             stepActiveLadder(key == "[" ? -1 : 1)
             return true
         }
@@ -1585,14 +1589,7 @@ class OverlayWindow: NSPanel {
                 return
             case ShortcutManager.shared.getShortcut(for: .toggleBackgroundDimming):
                 if isEditingAnnotationText { break }
-                if !event.isARepeat {
-                    let manager = CursorHighlightManager.shared
-                    manager.toggleSpotlightDimming()
-                    showToggleFeedback(
-                        manager.spotlightDimmingEnabled ? "Dimming On" : "Dimming Off",
-                        icon: manager.spotlightDimmingEnabled ? "🌘" : "☀️"
-                    )
-                }
+                toggleBackgroundDimming(with: event)
                 return
             default:
                 break
@@ -1942,6 +1939,16 @@ class OverlayWindow: NSPanel {
                 direction: direction))
     }
     
+    private func toggleBackgroundDimming(with event: NSEvent) {
+        guard !event.isARepeat else { return }
+        let manager = CursorHighlightManager.shared
+        manager.toggleSpotlightDimming()
+        showToggleFeedback(
+            manager.spotlightDimmingEnabled ? "Dimming On" : "Dimming Off",
+            icon: manager.spotlightDimmingEnabled ? "🌘" : "☀️"
+        )
+    }
+
     func showToggleFeedback(_ text: String, icon: String) {
         let hideToolFeedback = UserDefaults.standard.bool(forKey: UserDefaults.hideToolFeedbackKey)
         guard !hideToolFeedback else { return }

--- a/Annotate/ShortcutManager.swift
+++ b/Annotate/ShortcutManager.swift
@@ -19,8 +19,14 @@ enum ShortcutKey: String, CaseIterable {
     case lineWidthPicker = "w"
     case toggleBoard = "b"
     case toggleClickEffects = "k"
+    case toggleBackgroundDimming = "toggleBackgroundDimming"
 
-    var defaultKey: String { rawValue }
+    var defaultKey: String {
+        switch self {
+        case .toggleBackgroundDimming: return ""
+        default: return rawValue
+        }
+    }
 
     var displayName: String {
         switch self {
@@ -38,6 +44,7 @@ enum ShortcutKey: String, CaseIterable {
         case .lineWidthPicker: return "Line Width"
         case .toggleBoard: return "Toggle Board"
         case .toggleClickEffects: return "Toggle Cursor Highlight"
+        case .toggleBackgroundDimming: return "Toggle Background Dimming"
         }
     }
 }
@@ -85,6 +92,7 @@ class ShortcutManager: @unchecked Sendable {
     /// table (Space, Delete, Cmd+Z, Option+Command+T) are key-code or chord matched and cannot
     /// be typed into a shortcut field, so none of them needs reserving here.
     func isShortcutTaken(_ key: String, excluding tool: ShortcutKey) -> Bool {
+        guard !key.isEmpty else { return false }
         for otherTool in ShortcutKey.allCases where otherTool != tool {
             if getShortcut(for: otherTool) == key {
                 return true

--- a/Annotate/ShortcutsSettingsView.swift
+++ b/Annotate/ShortcutsSettingsView.swift
@@ -140,6 +140,13 @@ struct ShortcutsSettingsView: View {
                     shortcuts: $shortcuts,
                     editingShortcut: $editingShortcut
                 )
+                ShortcutSettingRow(
+                    tool: .toggleBackgroundDimming,
+                    label: "Toggle Background Dimming",
+                    description: "Toggle dimming while annotating; enables the spotlight if needed",
+                    shortcuts: $shortcuts,
+                    editingShortcut: $editingShortcut
+                )
             } header: {
                 SettingsHeader(
                     icon: "slider.horizontal.3",
@@ -189,6 +196,8 @@ struct ShortcutSettingRow: View {
     @State private var isHoveringKey = false
     @State private var isHoveringReset = false
 
+    private var shortcut: String { shortcuts[tool] ?? tool.defaultKey }
+
     var body: some View {
         LabeledContent {
             HStack(spacing: 8) {
@@ -201,7 +210,7 @@ struct ShortcutSettingRow: View {
                     .frame(minWidth: 60)
                 } else {
                     Button(action: { editingShortcut = tool }) {
-                        Text(shortcuts[tool] ?? tool.defaultKey)
+                        Text(shortcut.isEmpty ? "Not Set" : shortcut)
                             .font(.body.weight(.medium).monospaced())
                             .foregroundStyle(.primary)
                             .frame(minWidth: 32)
@@ -230,7 +239,8 @@ struct ShortcutSettingRow: View {
                             .foregroundStyle(isHoveringReset ? .secondary : .tertiary)
                     }
                     .buttonStyle(.plain)
-                    .help("Reset to default")
+                    .help(tool.defaultKey.isEmpty ? "Clear shortcut" : "Reset to default")
+                    .disabled(shortcut.isEmpty && tool.defaultKey.isEmpty)
                     .onHover { isHoveringReset = $0 }
                 }
             }

--- a/AnnotateTests/BackgroundDimmingShortcutTests.swift
+++ b/AnnotateTests/BackgroundDimmingShortcutTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+
+@testable import Annotate
+
+@MainActor
+final class BackgroundDimmingShortcutTests: XCTestCase {
+    private var window: OverlayWindow!
+    private var originalCursorManager: CursorHighlightManager!
+    private var originalShortcutManager: ShortcutManager!
+
+    override func setUp() {
+        super.setUp()
+        let defaults = TestUserDefaults.create()
+        originalCursorManager = CursorHighlightManager.shared
+        originalShortcutManager = ShortcutManager.shared
+        CursorHighlightManager.shared = CursorHighlightManager(userDefaults: defaults)
+        ShortcutManager.shared = ShortcutManager(userDefaults: defaults)
+        window = OverlayWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: .borderless, backing: .buffered, defer: false)
+    }
+
+    override func tearDown() {
+        window.stopFadeLoop()
+        window.orderOut(nil)
+        window = nil
+        CursorHighlightManager.shared = originalCursorManager
+        ShortcutManager.shared = originalShortcutManager
+        TestUserDefaults.removeSuite()
+        super.tearDown()
+    }
+
+    func testAssignedKeyTogglesDimmingAndClearedKeyDoesNothing() throws {
+        let manager = CursorHighlightManager.shared
+        let key = try XCTUnwrap(TestEvents.createKeyEvent(type: .keyDown, keyCode: 38, characters: "j"))
+        window.keyDown(with: key)
+        XCTAssertFalse(manager.cursorHighlightEnabled)
+
+        ShortcutManager.shared.setShortcut("j", for: .toggleBackgroundDimming)
+        window.keyDown(with: key)
+        XCTAssertTrue(manager.cursorHighlightEnabled)
+        XCTAssertTrue(manager.spotlightDimmingEnabled)
+
+        window.keyDown(with: key)
+        XCTAssertFalse(manager.spotlightDimmingEnabled)
+        XCTAssertTrue(manager.cursorHighlightEnabled)
+
+        ShortcutManager.shared.resetToDefault(tool: .toggleBackgroundDimming)
+        window.keyDown(with: key)
+        XCTAssertFalse(manager.spotlightDimmingEnabled)
+    }
+
+    func testEmptyKeyDoesNotMatchUnassignedShortcut() throws {
+        let key = try XCTUnwrap(TestEvents.createKeyEvent(type: .keyDown, keyCode: 0, characters: ""))
+        window.keyDown(with: key)
+        XCTAssertFalse(CursorHighlightManager.shared.cursorHighlightEnabled)
+        XCTAssertFalse(CursorHighlightManager.shared.spotlightDimmingEnabled)
+    }
+
+    func testRepeatsAndModifiedKeysDoNotToggleDimming() throws {
+        ShortcutManager.shared.setShortcut("j", for: .toggleBackgroundDimming)
+        let repeatKey = try XCTUnwrap(TestEvents.createKeyEvent(
+            type: .keyDown, keyCode: 38, characters: "j", isARepeat: true))
+        window.keyDown(with: repeatKey)
+        XCTAssertFalse(CursorHighlightManager.shared.spotlightDimmingEnabled)
+
+        for modifiers: NSEvent.ModifierFlags in [.command, .control, .option, .shift] {
+            let key = try XCTUnwrap(TestEvents.createKeyEvent(
+                type: .keyDown, keyCode: 38, modifierFlags: modifiers, characters: "j"))
+            window.keyDown(with: key)
+            XCTAssertFalse(CursorHighlightManager.shared.spotlightDimmingEnabled)
+        }
+    }
+
+    func testShortcutDoesNotToggleWhileEditingAnnotationText() throws {
+        ShortcutManager.shared.setShortcut("j", for: .toggleBackgroundDimming)
+        window.overlayView.createTextField(at: NSPoint(x: 100, y: 100), withText: "Label")
+        XCTAssertNotNil(window.overlayView.activeTextField)
+        let key = try XCTUnwrap(TestEvents.createKeyEvent(type: .keyDown, keyCode: 38, characters: "j"))
+
+        window.keyDown(with: key)
+
+        XCTAssertFalse(CursorHighlightManager.shared.spotlightDimmingEnabled)
+    }
+}

--- a/AnnotateTests/BackgroundDimmingShortcutTests.swift
+++ b/AnnotateTests/BackgroundDimmingShortcutTests.swift
@@ -18,6 +18,7 @@ final class BackgroundDimmingShortcutTests: XCTestCase {
         window = OverlayWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
             styleMask: .borderless, backing: .buffered, defer: false)
+        window.overlayView.pickerUserDefaultsOverride = defaults
     }
 
     override func tearDown() {
@@ -57,6 +58,47 @@ final class BackgroundDimmingShortcutTests: XCTestCase {
         XCTAssertFalse(CursorHighlightManager.shared.spotlightDimmingEnabled)
     }
 
+    func testBracketBindingsTakePrecedenceOverSizeStepping() throws {
+        let manager = CursorHighlightManager.shared
+        window.overlayView.currentTool = .pen
+
+        for (characters, keyCode): (String, UInt16) in [("[", 33), ("]", 30)] {
+            ShortcutManager.shared.setShortcut(characters, for: .toggleBackgroundDimming)
+            for useSendEvent in [false, true] {
+                manager.cursorHighlightEnabled = false
+                manager.spotlightDimmingEnabled = false
+                window.overlayView.currentLineWidth = 3
+                let key = try XCTUnwrap(TestEvents.createKeyEvent(
+                    type: .keyDown, keyCode: keyCode, characters: characters,
+                    windowNumber: window.windowNumber))
+                let repeatKey = try XCTUnwrap(TestEvents.createKeyEvent(
+                    type: .keyDown, keyCode: keyCode, characters: characters,
+                    windowNumber: window.windowNumber, isARepeat: true))
+
+                if useSendEvent {
+                    window.sendEvent(key)
+                    window.sendEvent(repeatKey)
+                } else {
+                    window.keyDown(with: key)
+                    window.keyDown(with: repeatKey)
+                }
+
+                XCTAssertTrue(manager.cursorHighlightEnabled)
+                XCTAssertTrue(manager.spotlightDimmingEnabled)
+                XCTAssertEqual(window.overlayView.currentLineWidth, 3)
+
+                if useSendEvent {
+                    window.sendEvent(key)
+                } else {
+                    window.keyDown(with: key)
+                }
+                XCTAssertFalse(manager.spotlightDimmingEnabled)
+                XCTAssertTrue(manager.cursorHighlightEnabled)
+                XCTAssertEqual(window.overlayView.currentLineWidth, 3)
+            }
+        }
+    }
+
     func testRepeatsAndModifiedKeysDoNotToggleDimming() throws {
         ShortcutManager.shared.setShortcut("j", for: .toggleBackgroundDimming)
         let repeatKey = try XCTUnwrap(TestEvents.createKeyEvent(
@@ -73,13 +115,16 @@ final class BackgroundDimmingShortcutTests: XCTestCase {
     }
 
     func testShortcutDoesNotToggleWhileEditingAnnotationText() throws {
-        ShortcutManager.shared.setShortcut("j", for: .toggleBackgroundDimming)
         window.overlayView.createTextField(at: NSPoint(x: 100, y: 100), withText: "Label")
         XCTAssertNotNil(window.overlayView.activeTextField)
-        let key = try XCTUnwrap(TestEvents.createKeyEvent(type: .keyDown, keyCode: 38, characters: "j"))
+        for (characters, keyCode): (String, UInt16) in [("j", 38), ("[", 33), ("]", 30)] {
+            ShortcutManager.shared.setShortcut(characters, for: .toggleBackgroundDimming)
+            let key = try XCTUnwrap(TestEvents.createKeyEvent(
+                type: .keyDown, keyCode: keyCode, characters: characters))
 
-        window.keyDown(with: key)
+            window.keyDown(with: key)
 
-        XCTAssertFalse(CursorHighlightManager.shared.spotlightDimmingEnabled)
+            XCTAssertFalse(CursorHighlightManager.shared.spotlightDimmingEnabled)
+        }
     }
 }

--- a/AnnotateTests/CursorHighlightManagerTests.swift
+++ b/AnnotateTests/CursorHighlightManagerTests.swift
@@ -46,6 +46,45 @@ final class CursorHighlightManagerTests: XCTestCase {
 
     // MARK: - Background Dimming Tests
 
+    func testToggleDimmingEnablesSpotlightAndLeavesItEnabledWhenDimmingTurnsOff() {
+        for autoDim in [false, true] {
+            manager.cursorHighlightEnabled = false
+            manager.spotlightDimmingEnabled = false
+            manager.spotlightAutoDimEnabled = autoDim
+
+            manager.toggleSpotlightDimming()
+
+            XCTAssertTrue(manager.cursorHighlightEnabled)
+            XCTAssertTrue(manager.shouldShowDimming)
+
+            manager.toggleSpotlightDimming()
+
+            XCTAssertTrue(manager.cursorHighlightEnabled)
+            XCTAssertFalse(manager.shouldShowDimming)
+            XCTAssertEqual(manager.spotlightAutoDimEnabled, autoDim)
+        }
+    }
+
+    func testToggleDimmingEnablesDimmingWhenDisabledSpotlightHasStoredDimmingOn() {
+        manager.spotlightDimmingEnabled = true
+        manager.cursorHighlightEnabled = false
+
+        manager.toggleSpotlightDimming()
+
+        XCTAssertTrue(manager.cursorHighlightEnabled)
+        XCTAssertTrue(manager.shouldShowDimming)
+    }
+
+    func testToggleDimmingDoesNotChangeClickEffects() {
+        for clickEffects in [false, true] {
+            manager.clickEffectsEnabled = clickEffects
+            manager.toggleSpotlightDimming()
+            XCTAssertEqual(manager.clickEffectsEnabled, clickEffects)
+            manager.toggleSpotlightDimming()
+            XCTAssertEqual(manager.clickEffectsEnabled, clickEffects)
+        }
+    }
+
     /// Dimming is off out of the box.
     func testSpotlightDimmingEnabledDefaultsToFalse() {
         XCTAssertFalse(manager.spotlightDimmingEnabled, "spotlightDimmingEnabled should default to false")

--- a/AnnotateTests/ShortcutManagerTests.swift
+++ b/AnnotateTests/ShortcutManagerTests.swift
@@ -136,6 +136,38 @@ final class ShortcutManagerTests: XCTestCase, Sendable {
     }
 
     // MARK: - Default Shortcut Tests
+
+    func testDimmingShortcutIsUnassignedUntilConfiguredAndCanBeCleared() {
+        let defaults = TestUserDefaults.create()
+        defer { TestUserDefaults.removeSuite() }
+        let manager = ShortcutManager(userDefaults: defaults)
+
+        XCTAssertEqual(manager.getShortcut(for: .toggleBackgroundDimming), "")
+        manager.setShortcut("j", for: .toggleBackgroundDimming)
+        XCTAssertEqual(
+            ShortcutManager(userDefaults: defaults).getShortcut(for: .toggleBackgroundDimming), "j")
+
+        manager.setShortcut("p", for: .toggleBackgroundDimming)
+        XCTAssertEqual(manager.getShortcut(for: .toggleBackgroundDimming), "j", "Pen already uses p")
+
+        manager.resetToDefault(tool: .toggleBackgroundDimming)
+        XCTAssertEqual(manager.getShortcut(for: .toggleBackgroundDimming), "")
+        manager.setShortcut("j", for: .toggleBackgroundDimming)
+        manager.resetAllToDefault()
+        XCTAssertEqual(manager.getShortcut(for: .toggleBackgroundDimming), "")
+    }
+
+    func testUnassignedShortcutsDoNotConflict() {
+        let defaults = TestUserDefaults.create()
+        defer { TestUserDefaults.removeSuite() }
+        let manager = ShortcutManager(userDefaults: defaults)
+
+        XCTAssertFalse(manager.isShortcutTaken("", excluding: .pen))
+        manager.setShortcut("", for: .pen)
+        manager.setShortcut("", for: .arrow)
+        XCTAssertEqual(manager.getShortcut(for: .pen), "")
+        XCTAssertEqual(manager.getShortcut(for: .arrow), "")
+    }
     
     func testAllDefaultShortcuts() {
         // Test all default keyboard shortcuts
@@ -152,12 +184,14 @@ final class ShortcutManagerTests: XCTestCase, Sendable {
         XCTAssertEqual(ShortcutKey.lineWidthPicker.defaultKey, "w", "Line Width should be 'w'")
         XCTAssertEqual(ShortcutKey.toggleBoard.defaultKey, "b", "Board should be 'b'")
         XCTAssertEqual(ShortcutKey.toggleClickEffects.defaultKey, "k", "Toggle Cursor Highlight should be 'k'")
+        XCTAssertEqual(ShortcutKey.toggleBackgroundDimming.defaultKey, "")
     }
     
     func testNoShortcutConflicts() {
-        // Verify all default shortcuts are unique
+        // Only assigned defaults reserve a key.
         var shortcuts = Set<String>()
-        for tool in ShortcutKey.allCases {
+        let assignedTools = ShortcutKey.allCases.filter { !$0.defaultKey.isEmpty }
+        for tool in assignedTools {
             let shortcut = tool.defaultKey
             XCTAssertFalse(
                 shortcuts.contains(shortcut),
@@ -166,8 +200,7 @@ final class ShortcutManagerTests: XCTestCase, Sendable {
             shortcuts.insert(shortcut)
         }
         
-        // Should have 12 unique shortcuts
-        XCTAssertEqual(shortcuts.count, ShortcutKey.allCases.count, "All shortcuts should be unique")
+        XCTAssertEqual(shortcuts.count, assignedTools.count, "All assigned shortcuts should be unique")
     }
     
     func testFirstLetterShortcuts() {

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ brew install --cask annotate
 | <kbd>V</kbd> | **Select**           | Select, move, and manage objects          |
 | <kbd>B</kbd> | **Board**            | Toggle whiteboard/blackboard              |
 | <kbd>K</kbd> | **Cursor Highlight** | Toggle cursor highlight and click effects |
-| Not set | **Background Dimming** | Assign a key in Settings → Shortcuts to toggle dimming while annotating |
+| Not set | **Background Dimming** | Toggle background dimming |
 
 #### ⚡ Quick Actions
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ brew install --cask annotate
 | <kbd>V</kbd> | **Select**           | Select, move, and manage objects          |
 | <kbd>B</kbd> | **Board**            | Toggle whiteboard/blackboard              |
 | <kbd>K</kbd> | **Cursor Highlight** | Toggle cursor highlight and click effects |
+| Not set | **Background Dimming** | Assign a key in Settings → Shortcuts to toggle dimming while annotating |
 
 #### ⚡ Quick Actions
 
@@ -376,7 +377,9 @@ Customize single-key shortcuts for tools and utilities, organized into categorie
 - **Drawing Tools**: Pen, Arrow, Line, Highlighter
 - **Shapes**: Rectangle, Circle
 - **Advanced Tools**: Counter, Text, Select, Eraser
-- **Utilities**: Color Picker, Line Width, Toggle Board, Toggle Cursor Highlight
+- **Utilities**: Color Picker, Line Width, Toggle Board, Toggle Cursor Highlight, Toggle Background Dimming
+
+**Toggle Background Dimming** is unassigned by default. Assign a key to use it while annotating, or clear it with the reset button. Turning dimming on also enables the spotlight if needed; turning it off leaves the spotlight enabled. This shortcut does not change click effects or the Dim Automatically preference.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/0dcdd2c2-a26d-4fd4-9860-8f7340554ada">


### PR DESCRIPTION
Adds **Toggle Background Dimming** under Settings → Shortcuts, unassigned by default and clearable with the reset button. The assigned key works while annotating without adding a menu item.

Turning dimming on enables the spotlight if needed; turning it off leaves the spotlight on. Click effects and Dim Automatically retain their current settings. Empty bindings, key repeats, modifier combinations, and annotation text editing do not trigger the shortcut.

Follow-up to #91. The layer visibility test correction is separate in #92.

Validation: `swift test` passed all 537 tests, including assignment/persistence/clearing, key routing, and dimming state transitions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shortcut for toggling background dimming.
  * Background dimming now works with the cursor spotlight and provides on/off feedback.
  * The shortcut can be configured in Utilities settings and is unassigned by default.
  * Dimming remains independent of click effects and automatic dimming preferences.

* **Documentation**
  * Added guidance for the background dimming feature and shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->