### PR TITLE
feat(shortcuts): Separate clear from restore-default

### DIFF
--- a/Annotate/OverlayWindow.swift
+++ b/Annotate/OverlayWindow.swift
@@ -721,7 +721,7 @@ class OverlayWindow: NSPanel {
             if performToolShortcut(mappedTo: key) {
                 return true
             }
-            if key == ShortcutManager.shared.getShortcut(for: .toggleBackgroundDimming) {
+            if ShortcutManager.shared.matches(key, tool: .toggleBackgroundDimming) {
                 toggleBackgroundDimming(with: event)
                 return true
             }
@@ -734,7 +734,7 @@ class OverlayWindow: NSPanel {
         guard !toolShortcuts.contains(key) else { return false }
 
         let colorKey = ShortcutManager.shared.getShortcut(for: .colorPicker)
-        if key == colorKey {
+        if ShortcutManager.shared.matches(key, tool: .colorPicker) {
             if isEditingAnnotationText {
                 return false
             }
@@ -743,7 +743,7 @@ class OverlayWindow: NSPanel {
         }
 
         let sizeKey = ShortcutManager.shared.getShortcut(for: .lineWidthPicker)
-        if key == sizeKey {
+        if ShortcutManager.shared.matches(key, tool: .lineWidthPicker) {
             if isEditingAnnotationText {
                 return false
             }
@@ -790,30 +790,30 @@ class OverlayWindow: NSPanel {
             ShortcutManager.shared.getShortcut(for: .text),
             ShortcutManager.shared.getShortcut(for: .select),
             ShortcutManager.shared.getShortcut(for: .eraser),
-        ])
+        ].filter { !$0.isEmpty })
     }
     private func performToolShortcut(mappedTo key: String) -> Bool {
         let shortcutManager = ShortcutManager.shared
         let appDelegate = AppDelegate.shared
-        if key == shortcutManager.getShortcut(for: .pen) {
+        if shortcutManager.matches(key, tool: .pen) {
             appDelegate?.enablePenMode(NSMenuItem())
-        } else if key == shortcutManager.getShortcut(for: .arrow) {
+        } else if shortcutManager.matches(key, tool: .arrow) {
             appDelegate?.enableArrowMode(NSMenuItem())
-        } else if key == shortcutManager.getShortcut(for: .line) {
+        } else if shortcutManager.matches(key, tool: .line) {
             appDelegate?.enableLineMode(NSMenuItem())
-        } else if key == shortcutManager.getShortcut(for: .highlighter) {
+        } else if shortcutManager.matches(key, tool: .highlighter) {
             appDelegate?.enableHighlighterMode(NSMenuItem())
-        } else if key == shortcutManager.getShortcut(for: .rectangle) {
+        } else if shortcutManager.matches(key, tool: .rectangle) {
             appDelegate?.enableRectangleMode(NSMenuItem())
-        } else if key == shortcutManager.getShortcut(for: .circle) {
+        } else if shortcutManager.matches(key, tool: .circle) {
             appDelegate?.enableCircleMode(NSMenuItem())
-        } else if key == shortcutManager.getShortcut(for: .counter) {
+        } else if shortcutManager.matches(key, tool: .counter) {
             appDelegate?.enableCounterMode(NSMenuItem())
-        } else if key == shortcutManager.getShortcut(for: .text) {
+        } else if shortcutManager.matches(key, tool: .text) {
             appDelegate?.enableTextMode(NSMenuItem())
-        } else if key == shortcutManager.getShortcut(for: .select) {
+        } else if shortcutManager.matches(key, tool: .select) {
             appDelegate?.enableSelectMode(NSMenuItem())
-        } else if key == shortcutManager.getShortcut(for: .eraser) {
+        } else if shortcutManager.matches(key, tool: .eraser) {
             appDelegate?.enableEraserMode(NSMenuItem())
         } else {
             return false
@@ -1538,61 +1538,71 @@ class OverlayWindow: NSPanel {
             cancelFreehandStroke()
         }
         
-        // Handle single-key shortcuts if no modifiers are pressed
+        // Handle single-key shortcuts if no modifiers are pressed.
+        // Empty bindings are unbound and must not match an empty key event.
         if !cmdPressed
-            && !key.isEmpty
             && event.modifierFlags.intersection([.command, .option, .control, .shift]).isEmpty
         {
-            switch key {
-            case ShortcutManager.shared.getShortcut(for: .pen):
+            let shortcuts = ShortcutManager.shared
+            if shortcuts.matches(key, tool: .pen) {
                 AppDelegate.shared?.enablePenMode(NSMenuItem())
                 return
-            case ShortcutManager.shared.getShortcut(for: .arrow):
+            }
+            if shortcuts.matches(key, tool: .arrow) {
                 AppDelegate.shared?.enableArrowMode(NSMenuItem())
                 return
-            case ShortcutManager.shared.getShortcut(for: .line):
+            }
+            if shortcuts.matches(key, tool: .line) {
                 AppDelegate.shared?.enableLineMode(NSMenuItem())
                 return
-            case ShortcutManager.shared.getShortcut(for: .highlighter):
+            }
+            if shortcuts.matches(key, tool: .highlighter) {
                 AppDelegate.shared?.enableHighlighterMode(NSMenuItem())
                 return
-            case ShortcutManager.shared.getShortcut(for: .rectangle):
+            }
+            if shortcuts.matches(key, tool: .rectangle) {
                 AppDelegate.shared?.enableRectangleMode(NSMenuItem())
                 return
-            case ShortcutManager.shared.getShortcut(for: .circle):
+            }
+            if shortcuts.matches(key, tool: .circle) {
                 AppDelegate.shared?.enableCircleMode(NSMenuItem())
                 return
-            case ShortcutManager.shared.getShortcut(for: .counter):
+            }
+            if shortcuts.matches(key, tool: .counter) {
                 AppDelegate.shared?.enableCounterMode(NSMenuItem())
                 return
-            case ShortcutManager.shared.getShortcut(for: .text):
+            }
+            if shortcuts.matches(key, tool: .text) {
                 AppDelegate.shared?.enableTextMode(NSMenuItem())
                 return
-            case ShortcutManager.shared.getShortcut(for: .select):
+            }
+            if shortcuts.matches(key, tool: .select) {
                 AppDelegate.shared?.enableSelectMode(NSMenuItem())
                 return
-            case ShortcutManager.shared.getShortcut(for: .eraser):
+            }
+            if shortcuts.matches(key, tool: .eraser) {
                 AppDelegate.shared?.enableEraserMode(NSMenuItem())
                 return
-            case ShortcutManager.shared.getShortcut(for: .colorPicker):
-                if isEditingAnnotationText { break }
-                AppDelegate.shared?.showColorPicker(nil)
-                return
-            case ShortcutManager.shared.getShortcut(for: .lineWidthPicker):
+            }
+            if shortcuts.matches(key, tool: .colorPicker) {
+                if !isEditingAnnotationText {
+                    AppDelegate.shared?.showColorPicker(nil)
+                    return
+                }
+            } else if shortcuts.matches(key, tool: .lineWidthPicker) {
                 AppDelegate.shared?.showLineWidthPicker(nil)
                 return
-            case ShortcutManager.shared.getShortcut(for: .toggleBoard):
+            } else if shortcuts.matches(key, tool: .toggleBoard) {
                 AppDelegate.shared?.toggleBoardVisibility(nil)
                 return
-            case ShortcutManager.shared.getShortcut(for: .toggleClickEffects):
+            } else if shortcuts.matches(key, tool: .toggleClickEffects) {
                 AppDelegate.shared?.toggleClickEffects(nil)
                 return
-            case ShortcutManager.shared.getShortcut(for: .toggleBackgroundDimming):
-                if isEditingAnnotationText { break }
-                toggleBackgroundDimming(with: event)
-                return
-            default:
-                break
+            } else if shortcuts.matches(key, tool: .toggleBackgroundDimming) {
+                if !isEditingAnnotationText {
+                    toggleBackgroundDimming(with: event)
+                    return
+                }
             }
         }
 

--- a/Annotate/ShortcutField.swift
+++ b/Annotate/ShortcutField.swift
@@ -1,6 +1,29 @@
 import SwiftUI
 import AppKit
 
+struct ShortcutRecordingEventResult {
+    let editingShortcut: ShortcutKey?
+    let consumesEvent: Bool
+}
+
+enum ShortcutRecordingEventHandler {
+    static func handle(
+        _ event: NSEvent,
+        editingShortcut: ShortcutKey?
+    ) -> ShortcutRecordingEventResult {
+        if event.type == .keyDown && event.keyCode == 53 {
+            return ShortcutRecordingEventResult(editingShortcut: nil, consumesEvent: true)
+        }
+        if event.type == .leftMouseDown || event.type == .rightMouseDown {
+            return ShortcutRecordingEventResult(editingShortcut: nil, consumesEvent: false)
+        }
+        return ShortcutRecordingEventResult(
+            editingShortcut: editingShortcut,
+            consumesEvent: false
+        )
+    }
+}
+
 struct ShortcutField: View {
     let tool: ShortcutKey
     @Binding var shortcuts: [ShortcutKey: String]
@@ -58,15 +81,12 @@ struct ShortcutField: View {
 
     private func setupEventMonitor() {
         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown, .keyDown]) { event in
-            // Escape key (keyCode 53)
-            if event.type == .keyDown && event.keyCode == 53 {
-                editingShortcut = nil
-                return nil
-            }
-            if event.type == .leftMouseDown || event.type == .rightMouseDown {
-                editingShortcut = nil
-            }
-            return event
+            let result = ShortcutRecordingEventHandler.handle(
+                event,
+                editingShortcut: editingShortcut
+            )
+            editingShortcut = result.editingShortcut
+            return result.consumesEvent ? nil : event
         }
     }
 

--- a/Annotate/ShortcutManager.swift
+++ b/Annotate/ShortcutManager.swift
@@ -74,6 +74,17 @@ class ShortcutManager: @unchecked Sendable {
         NotificationCenter.default.post(name: .shortcutsDidChange, object: nil)
     }
 
+    /// Stores an empty binding so the shortcut is unbound (Not Set).
+    func clearShortcut(tool: ShortcutKey) {
+        setShortcut("", for: tool)
+    }
+
+    /// True when `key` is a non-empty bound shortcut for `tool`. Empty keys never match.
+    func matches(_ key: String, tool: ShortcutKey) -> Bool {
+        let shortcut = getShortcut(for: tool)
+        return !key.isEmpty && !shortcut.isEmpty && key == shortcut
+    }
+
     func resetToDefault(tool: ShortcutKey) {
         defaults.removeObject(forKey: shortcutPrefix + tool.rawValue)
         defaults.synchronize()

--- a/Annotate/ShortcutManager.swift
+++ b/Annotate/ShortcutManager.swift
@@ -85,10 +85,16 @@ class ShortcutManager: @unchecked Sendable {
         return !key.isEmpty && !shortcut.isEmpty && key == shortcut
     }
 
-    func resetToDefault(tool: ShortcutKey) {
+    @discardableResult
+    func resetToDefault(tool: ShortcutKey) -> Bool {
+        if isShortcutTaken(tool.defaultKey, excluding: tool) {
+            print("Default shortcut '\(tool.defaultKey)' is already in use.")
+            return false
+        }
         defaults.removeObject(forKey: shortcutPrefix + tool.rawValue)
         defaults.synchronize()
         NotificationCenter.default.post(name: .shortcutsDidChange, object: nil)
+        return true
     }
 
     func resetAllToDefault() {

--- a/Annotate/ShortcutsSettingsView.swift
+++ b/Annotate/ShortcutsSettingsView.swift
@@ -1,5 +1,35 @@
 import SwiftUI
 
+struct ShortcutSettingActionResult {
+    let shortcuts: [ShortcutKey: String]
+    let restoreConflict: Bool
+}
+
+enum ShortcutSettingAction {
+    case clear
+    case restoreDefault
+
+    @MainActor
+    func perform(
+        tool: ShortcutKey,
+        manager: ShortcutManager = .shared
+    ) -> ShortcutSettingActionResult {
+        let restoreConflict: Bool
+        switch self {
+        case .clear:
+            manager.clearShortcut(tool: tool)
+            restoreConflict = false
+        case .restoreDefault:
+            restoreConflict = !manager.resetToDefault(tool: tool)
+        }
+
+        return ShortcutSettingActionResult(
+            shortcuts: manager.allShortcuts,
+            restoreConflict: restoreConflict
+        )
+    }
+}
+
 struct ShortcutsSettingsView: View {
     @State private var shortcuts: [ShortcutKey: String] = ShortcutManager.shared.allShortcuts
     @State private var editingShortcut: ShortcutKey?
@@ -196,6 +226,7 @@ struct ShortcutSettingRow: View {
     @State private var isHoveringKey = false
     @State private var isHoveringClear = false
     @State private var isHoveringRestore = false
+    @State private var showRestoreConflict = false
 
     private var shortcut: String { shortcuts[tool] ?? tool.defaultKey }
 
@@ -232,8 +263,8 @@ struct ShortcutSettingRow: View {
                 }
 
                 Button {
-                    ShortcutManager.shared.clearShortcut(tool: tool)
-                    shortcuts = ShortcutManager.shared.allShortcuts
+                    let result = ShortcutSettingAction.clear.perform(tool: tool)
+                    shortcuts = result.shortcuts
                     editingShortcut = nil
                 } label: {
                     Image(systemName: "xmark.circle.fill")
@@ -246,9 +277,10 @@ struct ShortcutSettingRow: View {
                 .onHover { isHoveringClear = $0 }
 
                 Button {
-                    ShortcutManager.shared.resetToDefault(tool: tool)
-                    shortcuts = ShortcutManager.shared.allShortcuts
+                    let result = ShortcutSettingAction.restoreDefault.perform(tool: tool)
+                    shortcuts = result.shortcuts
                     editingShortcut = nil
+                    showRestoreConflict = result.restoreConflict
                 } label: {
                     Image(systemName: "arrow.counterclockwise.circle.fill")
                         .font(.body)
@@ -258,6 +290,13 @@ struct ShortcutSettingRow: View {
                 .help("Restore default")
                 .disabled(shortcut == tool.defaultKey)
                 .onHover { isHoveringRestore = $0 }
+                .alert("Default Shortcut Unavailable", isPresented: $showRestoreConflict) {
+                    Button("OK") {}
+                } message: {
+                    Text(
+                        "The default shortcut “\(tool.defaultKey)” is already assigned. Clear it from the other action first."
+                    )
+                }
             }
         } label: {
             Text(label)

--- a/Annotate/ShortcutsSettingsView.swift
+++ b/Annotate/ShortcutsSettingsView.swift
@@ -12,8 +12,9 @@ enum ShortcutSettingAction {
     @MainActor
     func perform(
         tool: ShortcutKey,
-        manager: ShortcutManager = .shared
+        manager: ShortcutManager? = nil
     ) -> ShortcutSettingActionResult {
+        let manager = manager ?? .shared
         let restoreConflict: Bool
         switch self {
         case .clear:

--- a/Annotate/ShortcutsSettingsView.swift
+++ b/Annotate/ShortcutsSettingsView.swift
@@ -194,7 +194,8 @@ struct ShortcutSettingRow: View {
     @Binding var editingShortcut: ShortcutKey?
 
     @State private var isHoveringKey = false
-    @State private var isHoveringReset = false
+    @State private var isHoveringClear = false
+    @State private var isHoveringRestore = false
 
     private var shortcut: String { shortcuts[tool] ?? tool.defaultKey }
 
@@ -228,21 +229,35 @@ struct ShortcutSettingRow: View {
                     .buttonStyle(.plain)
                     .opacity(isHoveringKey ? 0.8 : 1.0)
                     .onHover { isHoveringKey = $0 }
-
-                    Button {
-                        ShortcutManager.shared.resetToDefault(tool: tool)
-                        shortcuts = ShortcutManager.shared.allShortcuts
-                        editingShortcut = nil
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.body)
-                            .foregroundStyle(isHoveringReset ? .secondary : .tertiary)
-                    }
-                    .buttonStyle(.plain)
-                    .help(tool.defaultKey.isEmpty ? "Clear shortcut" : "Reset to default")
-                    .disabled(shortcut.isEmpty && tool.defaultKey.isEmpty)
-                    .onHover { isHoveringReset = $0 }
                 }
+
+                Button {
+                    ShortcutManager.shared.clearShortcut(tool: tool)
+                    shortcuts = ShortcutManager.shared.allShortcuts
+                    editingShortcut = nil
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.body)
+                        .foregroundStyle(isHoveringClear ? .secondary : .tertiary)
+                }
+                .buttonStyle(.plain)
+                .help("Clear shortcut")
+                .disabled(shortcut.isEmpty)
+                .onHover { isHoveringClear = $0 }
+
+                Button {
+                    ShortcutManager.shared.resetToDefault(tool: tool)
+                    shortcuts = ShortcutManager.shared.allShortcuts
+                    editingShortcut = nil
+                } label: {
+                    Image(systemName: "arrow.counterclockwise.circle.fill")
+                        .font(.body)
+                        .foregroundStyle(isHoveringRestore ? .secondary : .tertiary)
+                }
+                .buttonStyle(.plain)
+                .help("Restore default")
+                .disabled(shortcut == tool.defaultKey)
+                .onHover { isHoveringRestore = $0 }
             }
         } label: {
             Text(label)

--- a/AnnotateTests/BackgroundDimmingShortcutTests.swift
+++ b/AnnotateTests/BackgroundDimmingShortcutTests.swift
@@ -46,7 +46,7 @@ final class BackgroundDimmingShortcutTests: XCTestCase {
         XCTAssertFalse(manager.spotlightDimmingEnabled)
         XCTAssertTrue(manager.cursorHighlightEnabled)
 
-        ShortcutManager.shared.resetToDefault(tool: .toggleBackgroundDimming)
+        ShortcutManager.shared.clearShortcut(tool: .toggleBackgroundDimming)
         window.keyDown(with: key)
         XCTAssertFalse(manager.spotlightDimmingEnabled)
     }

--- a/AnnotateTests/ShortcutFieldTests.swift
+++ b/AnnotateTests/ShortcutFieldTests.swift
@@ -172,26 +172,60 @@ final class ShortcutFieldTests: XCTestCase {
         XCTAssertEqual(afterShortcut, initialShortcut, "Empty key should not change shortcut")
     }
 
-    func testEscapeCancelsRecordingWithoutClearing() {
-        var editingShortcut: ShortcutKey? = .pen
-        let before = ShortcutManager.shared.getShortcut(for: .pen)
+    func testEscapeCancelsRecordingWithoutClearing() throws {
+        let manager = ShortcutManager(userDefaults: testDefaults)
+        let before = manager.getShortcut(for: .pen)
         XCTAssertEqual(before, "p")
+        let escape = try XCTUnwrap(
+            TestEvents.createKeyEvent(type: .keyDown, keyCode: 53)
+        )
 
-        editingShortcut = nil
+        let result = ShortcutRecordingEventHandler.handle(
+            escape,
+            editingShortcut: .pen
+        )
 
-        XCTAssertNil(editingShortcut, "Escape should cancel recording")
+        XCTAssertNil(result.editingShortcut, "Escape should cancel recording")
+        XCTAssertTrue(result.consumesEvent, "Escape should not propagate beyond the recorder")
         XCTAssertEqual(
-            ShortcutManager.shared.getShortcut(for: .pen), before,
+            manager.getShortcut(for: .pen), before,
             "Canceling recording must leave the shortcut unchanged")
     }
 
     func testClearButtonUnbindsWithoutRecording() {
-        ShortcutManager.shared.setShortcut("f", for: .pen)
-        ShortcutManager.shared.clearShortcut(tool: .pen)
+        let manager = ShortcutManager(userDefaults: testDefaults)
+        manager.setShortcut("f", for: .pen)
 
-        XCTAssertEqual(
-            ShortcutManager.shared.getShortcut(for: .pen), "",
-            "The clear button should unbind without recording a key")
+        let result = ShortcutSettingAction.clear.perform(tool: .pen, manager: manager)
+
+        XCTAssertEqual(manager.getShortcut(for: .pen), "")
+        XCTAssertEqual(result.shortcuts[.pen], "")
+        XCTAssertFalse(result.restoreConflict)
+    }
+
+    func testRestoreButtonRestoresDefaultAndReportsConflicts() {
+        let manager = ShortcutManager(userDefaults: testDefaults)
+        manager.clearShortcut(tool: .pen)
+
+        let restored = ShortcutSettingAction.restoreDefault.perform(
+            tool: .pen,
+            manager: manager
+        )
+
+        XCTAssertEqual(restored.shortcuts[.pen], "p")
+        XCTAssertFalse(restored.restoreConflict)
+
+        manager.clearShortcut(tool: .pen)
+        manager.setShortcut("p", for: .arrow)
+
+        let rejected = ShortcutSettingAction.restoreDefault.perform(
+            tool: .pen,
+            manager: manager
+        )
+
+        XCTAssertEqual(rejected.shortcuts[.pen], "")
+        XCTAssertEqual(rejected.shortcuts[.arrow], "p")
+        XCTAssertTrue(rejected.restoreConflict)
     }
 
     func testLowercaseConversion() {

--- a/AnnotateTests/ShortcutFieldTests.swift
+++ b/AnnotateTests/ShortcutFieldTests.swift
@@ -172,6 +172,28 @@ final class ShortcutFieldTests: XCTestCase {
         XCTAssertEqual(afterShortcut, initialShortcut, "Empty key should not change shortcut")
     }
 
+    func testEscapeCancelsRecordingWithoutClearing() {
+        var editingShortcut: ShortcutKey? = .pen
+        let before = ShortcutManager.shared.getShortcut(for: .pen)
+        XCTAssertEqual(before, "p")
+
+        editingShortcut = nil
+
+        XCTAssertNil(editingShortcut, "Escape should cancel recording")
+        XCTAssertEqual(
+            ShortcutManager.shared.getShortcut(for: .pen), before,
+            "Canceling recording must leave the shortcut unchanged")
+    }
+
+    func testClearButtonUnbindsWithoutRecording() {
+        ShortcutManager.shared.setShortcut("f", for: .pen)
+        ShortcutManager.shared.clearShortcut(tool: .pen)
+
+        XCTAssertEqual(
+            ShortcutManager.shared.getShortcut(for: .pen), "",
+            "The clear button should unbind without recording a key")
+    }
+
     func testLowercaseConversion() {
         ShortcutManager.shared.setShortcut("F", for: .pen)
 

--- a/AnnotateTests/ShortcutManagerTests.swift
+++ b/AnnotateTests/ShortcutManagerTests.swift
@@ -162,9 +162,22 @@ final class ShortcutManagerTests: XCTestCase, Sendable {
 
         manager.clearShortcut(tool: .pen)
         XCTAssertEqual(manager.getShortcut(for: .pen), "")
-        manager.resetToDefault(tool: .pen)
+        XCTAssertTrue(manager.resetToDefault(tool: .pen))
         XCTAssertEqual(manager.getShortcut(for: .pen), ShortcutKey.pen.defaultKey)
         XCTAssertTrue(manager.matches("p", tool: .pen))
+    }
+
+    func testResetToDefaultRejectsAReassignedDefault() {
+        let defaults = TestUserDefaults.create()
+        defer { TestUserDefaults.removeSuite() }
+        let manager = ShortcutManager(userDefaults: defaults)
+
+        manager.clearShortcut(tool: .pen)
+        manager.setShortcut("p", for: .arrow)
+
+        XCTAssertFalse(manager.resetToDefault(tool: .pen))
+        XCTAssertEqual(manager.getShortcut(for: .pen), "")
+        XCTAssertEqual(manager.getShortcut(for: .arrow), "p")
     }
 
     func testResetAllRestoresLetterDefaultsAndLeavesDimmingUnset() {

--- a/AnnotateTests/ShortcutManagerTests.swift
+++ b/AnnotateTests/ShortcutManagerTests.swift
@@ -137,6 +137,52 @@ final class ShortcutManagerTests: XCTestCase, Sendable {
 
     // MARK: - Default Shortcut Tests
 
+    func testClearShortcutUnbindsWithoutRestoringDefault() {
+        let defaults = TestUserDefaults.create()
+        defer { TestUserDefaults.removeSuite() }
+        let manager = ShortcutManager(userDefaults: defaults)
+
+        XCTAssertEqual(manager.getShortcut(for: .pen), "p")
+        manager.setShortcut("f", for: .pen)
+        manager.clearShortcut(tool: .pen)
+        XCTAssertEqual(manager.getShortcut(for: .pen), "")
+        XCTAssertFalse(manager.isShortcutTaken("", excluding: .arrow))
+        XCTAssertFalse(manager.matches("p", tool: .pen))
+        XCTAssertFalse(manager.matches("", tool: .pen))
+
+        manager.setShortcut("p", for: .arrow)
+        XCTAssertEqual(manager.getShortcut(for: .arrow), "p")
+        XCTAssertEqual(manager.getShortcut(for: .pen), "")
+    }
+
+    func testResetToDefaultRestoresLetterAfterClear() {
+        let defaults = TestUserDefaults.create()
+        defer { TestUserDefaults.removeSuite() }
+        let manager = ShortcutManager(userDefaults: defaults)
+
+        manager.clearShortcut(tool: .pen)
+        XCTAssertEqual(manager.getShortcut(for: .pen), "")
+        manager.resetToDefault(tool: .pen)
+        XCTAssertEqual(manager.getShortcut(for: .pen), ShortcutKey.pen.defaultKey)
+        XCTAssertTrue(manager.matches("p", tool: .pen))
+    }
+
+    func testResetAllRestoresLetterDefaultsAndLeavesDimmingUnset() {
+        let defaults = TestUserDefaults.create()
+        defer { TestUserDefaults.removeSuite() }
+        let manager = ShortcutManager(userDefaults: defaults)
+
+        manager.clearShortcut(tool: .pen)
+        manager.setShortcut("y", for: .arrow)
+        manager.setShortcut("j", for: .toggleBackgroundDimming)
+        manager.resetAllToDefault()
+
+        XCTAssertEqual(manager.getShortcut(for: .pen), "p")
+        XCTAssertEqual(manager.getShortcut(for: .arrow), "a")
+        XCTAssertEqual(manager.getShortcut(for: .toggleBackgroundDimming), "")
+        XCTAssertEqual(ShortcutKey.toggleBackgroundDimming.defaultKey, "")
+    }
+
     func testDimmingShortcutIsUnassignedUntilConfiguredAndCanBeCleared() {
         let defaults = TestUserDefaults.create()
         defer { TestUserDefaults.removeSuite() }
@@ -150,11 +196,29 @@ final class ShortcutManagerTests: XCTestCase, Sendable {
         manager.setShortcut("p", for: .toggleBackgroundDimming)
         XCTAssertEqual(manager.getShortcut(for: .toggleBackgroundDimming), "j", "Pen already uses p")
 
+        manager.clearShortcut(tool: .toggleBackgroundDimming)
+        XCTAssertEqual(manager.getShortcut(for: .toggleBackgroundDimming), "")
+        manager.setShortcut("j", for: .toggleBackgroundDimming)
         manager.resetToDefault(tool: .toggleBackgroundDimming)
         XCTAssertEqual(manager.getShortcut(for: .toggleBackgroundDimming), "")
         manager.setShortcut("j", for: .toggleBackgroundDimming)
         manager.resetAllToDefault()
         XCTAssertEqual(manager.getShortcut(for: .toggleBackgroundDimming), "")
+    }
+
+    func testMatchesIgnoresEmptyBindingsAndEmptyKeys() {
+        let defaults = TestUserDefaults.create()
+        defer { TestUserDefaults.removeSuite() }
+        let manager = ShortcutManager(userDefaults: defaults)
+
+        XCTAssertTrue(manager.matches("p", tool: .pen))
+        XCTAssertFalse(manager.matches("", tool: .pen))
+        XCTAssertFalse(manager.matches("p", tool: .arrow))
+
+        manager.clearShortcut(tool: .pen)
+        XCTAssertFalse(manager.matches("p", tool: .pen))
+        XCTAssertFalse(manager.matches("", tool: .pen))
+        XCTAssertFalse(manager.matches("", tool: .toggleBackgroundDimming))
     }
 
     func testUnassignedShortcutsDoNotConflict() {

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Customize single-key shortcuts for tools and utilities, organized into categorie
 - **Advanced Tools**: Counter, Text, Select, Eraser
 - **Utilities**: Color Picker, Line Width, Toggle Board, Toggle Cursor Highlight, Toggle Background Dimming
 
-**Toggle Background Dimming** is unassigned by default. Assign a key to use it while annotating, or clear it with the reset button. Turning dimming on also enables the spotlight if needed; turning it off leaves the spotlight enabled. This shortcut does not change click effects or the Dim Automatically preference.
+**Toggle Background Dimming** is unassigned by default. Assign a key to use it while annotating. Each row can clear its shortcut (Not Set) or restore that row's default; **Reset All to Default** restores every letter default and leaves dimming unset. Turning dimming on also enables the spotlight if needed; turning it off leaves the spotlight enabled. This shortcut does not change click effects or the Dim Automatically preference.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/0dcdd2c2-a26d-4fd4-9860-8f7340554ada">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #93. The row ✕ was calling `resetToDefault`, so letter tools snapped back to their default key and only `toggleBackgroundDimming` (default `""`) could land on Not Set.

**Behavior**
- Per-row ✕ **clears / unbinds** the shortcut (`clearShortcut` stores `""` → Not Set). Empty bindings do not collide in `isShortcutTaken`.
- Per-row ↺ **restores default** (`resetToDefault` → `tool.defaultKey`: letters for tools, `""` for dimming).
- **Reset All to Default** still bulk-restores letter defaults and leaves dimming unset.
- Recording: Escape still cancels without changing the binding. Clear is a dedicated button, including while recording.
- Overlay key handling uses `ShortcutManager.matches` so empty is unbound (no accidental firing on empty key events).

**Help text:** “Clear shortcut” vs “Restore default”.

**Tests:** clear vs reset-to-default vs Reset All; dimming still defaults unset; empty keys do not match.

Did not run `xcodebuild` or launch Annotate.app (per request).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e68c622-1832-4072-8890-c665e1f31e48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e68c622-1832-4072-8890-c665e1f31e48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added separate controls to clear a shortcut or restore its default.
  - Cleared shortcuts now appear as “Not Set” and no longer trigger actions.
  - Improved shortcut matching, including support for unassigned shortcuts.
  - Added a warning when a default shortcut is already assigned elsewhere.

- **Bug Fixes**
  - Prevented shortcut actions from activating while editing annotation text.
  - Canceling shortcut recording now preserves the existing assignment.
  - Prevented restoring defaults when the default key is already in use.

- **Documentation**
  - Updated shortcut guidance to explain clearing, restoring defaults, and Reset All behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->